### PR TITLE
Player Death Options and Antagonist Updates

### DIFF
--- a/Sources/epoch_code/compile/EPOCH_supportCopter.sqf
+++ b/Sources/epoch_code/compile/EPOCH_supportCopter.sqf
@@ -22,16 +22,29 @@ _grp = createGroup RESISTANCE;
 _grp setBehaviour "COMBAT";
 _grp setCombatMode "RED";
 
-// TODO: make configized
-_arrUnits = ["I_Soldier_EPOCH", "I_Soldier2_EPOCH", "I_Soldier3_EPOCH"];
+_minAISkill = getNumber (getMissionConfig "CfgEpochUAVSupport" >> "minAISkill");
+_arrUnits = getArray (getMissionConfig "CfgEpochUAVSupport" >> "unitTypes");
+_unitCount = getNumber (getMissionConfig "CfgEpochUAVSupport" >> "maxUnitNum");
 _arrSkills = ["aimingAccuracy","aimingShake","aimingSpeed","endurance","spotDistance","spotTime","courage","reloadSpeed","commanding","general"];
+_arrVals = [
+getNumber (getMissionConfig "CfgEpochUAVSupport" >> "maxAimingAccuracy"),
+getNumber (getMissionConfig "CfgEpochUAVSupport" >> "maxAimingShake"),
+getNumber (getMissionConfig "CfgEpochUAVSupport" >> "maxAimingSpeed"),
+getNumber (getMissionConfig "CfgEpochUAVSupport" >> "maxEndurance"),
+getNumber (getMissionConfig "CfgEpochUAVSupport" >> "maxSpotDistance"),
+getNumber (getMissionConfig "CfgEpochUAVSupport" >> "maxSpotTime"),
+getNumber (getMissionConfig "CfgEpochUAVSupport" >> "maxCourage"),
+getNumber (getMissionConfig "CfgEpochUAVSupport" >> "maxReloadSpeed"),
+getNumber (getMissionConfig "CfgEpochUAVSupport" >> "maxCommanding"),
+getNumber (getMissionConfig "CfgEpochUAVSupport" >> "maxGeneral")
+];
 _units = [];
-for "_i" from 0 to ((count _arrUnits)-1) do {
+for "_i" from 0 to (_unitCount - 1) do {
 
-	_unit = _grp createUnit[(_arrUnits select _i), _pos, [], 0, "FORM"];
+	_unit = _grp createUnit[(_arrUnits select (floor random count _arrUnits)), _pos, [], 0, "FORM"];
 	_units pushBack _unit;
 
-	_unit setSkill 0.6;
+	//_unit setSkill 0.6;
 	_unit setRank "Private";
 
 	_unit enableAI "TARGET";
@@ -41,9 +54,9 @@ for "_i" from 0 to ((count _arrUnits)-1) do {
 	_unit disableAI "FSM";
 
 	for "_i" from 0 to ((count _arrSkills)-1) do {
-		_aiskill = ((floor(random 10))+1)/10;
-		if (_aiskill<0.6) then {_aiskill=0.6};
-		_unit setSkill [_arrSkills select _i,_aiskill];
+		_aiskill = floor random (_arrVals select _i);
+		if (_aiskill<_minAISkill) then {_aiskill=_minAISkill};
+		_unit setSkill [_arrSkills select _i,_arrVals select _i];
 	};
 	
 	if (_i == 0) then {

--- a/Sources/epoch_code/compile/EPOCH_supportCopter.sqf
+++ b/Sources/epoch_code/compile/EPOCH_supportCopter.sqf
@@ -41,7 +41,7 @@ getNumber (getMissionConfig "CfgEpochUAVSupport" >> "maxGeneral")
 _units = [];
 for "_i" from 0 to (_unitCount - 1) do {
 
-	_unit = _grp createUnit[(_arrUnits select (floor random count _arrUnits)), _pos, [], 0, "FORM"];
+	_unit = _grp createUnit[selectRandom _arrUnits, _pos, [], 0, "FORM"];
 	_units pushBack _unit;
 
 	//_unit setSkill 0.6;

--- a/Sources/epoch_code/compile/EPOCH_unitSpawn.sqf
+++ b/Sources/epoch_code/compile/EPOCH_unitSpawn.sqf
@@ -39,14 +39,14 @@ _jammers = [];
 _config = 'CfgEpochClient' call EPOCH_returnConfig;
 _jammerRange = getNumber(_config >> "buildingJammerRange");
 _jammers = nearestObjects[_targetPos, ["PlotPole_EPOCH"], _jammerRange];
-if(count _jammers > 0 && !(_unitClass in _nonJammer))exitWith{
-if(_doVariable)then{["<t size='1.6' color='#99ffffff'>Not allowed near a base - Please respawn !</t>", 5] call Epoch_dynamicText;};
+if(count _jammers > 0 && (_unitClass in _nonJammer))exitWith{
+	if(_doVariable)then{["<t size='1.6' color='#99ffffff'>Not allowed near a base - Please respawn !</t>", 5] call Epoch_dynamicText;};
 };
 
 _restricted = [];
 _restricted = nearestObjects [_targetPos, ["ProtectionZone_Invisible_F"], _nonTraderAIRange];
-if(count _restricted > 0 && !(_unitClass in _nonTrader))exitWith{
-if(_doVariable)then{["<t size='1.6' color='#99ffffff'>Not allowed near a trader - Please respawn !</t>", 5] call Epoch_dynamicText;};
+if(count _restricted > 0 && (_unitClass in _nonTrader))exitWith{
+	if(_doVariable)then{["<t size='1.6' color='#99ffffff'>Not allowed near a trader - Please respawn !</t>", 5] call Epoch_dynamicText;};
 };
 
 _disableAI = {

--- a/Sources/epoch_code/compile/EPOCH_unitSpawn.sqf
+++ b/Sources/epoch_code/compile/EPOCH_unitSpawn.sqf
@@ -1,7 +1,7 @@
 /*
 	Author: Aaron Clark - EpochMod.com
 
-    Contributors:
+    Contributors: Andrew Gregory
 
 	Description:
 	Antagonist spawn function
@@ -12,15 +12,19 @@
     Github:
     https://github.com/EpochModTeam/Epoch/tree/master/Sources/epoch_code/compile/EPOCH_unitSpawn.sqf
 */
-private ["_unit","_sapperNum","_config","_bomb","_targetPos","_grp","_driver","_index","_nonJammer","_nonTrader","_jammers","_jammerRange","_restricted","_disableAI"];
-params ["_unitClass"];
-
+private ["_unit","_sapperNum","_config","_targetPos","_grp","_driver","_index","_nonJammer","_nonTrader","_jammers","_jammerRange","_restricted","_disableAI"];
+params ["_unitClass","_trgt","_doVariable"];
+private _bomb = objNull;
+if(isNil "_doVariable")then{_doVariable=false;};
+if(isNil "_trgt")then{_trgt=player;};
+diag_log format["Epoch: ADMIN: Antagonist %1 Spawning on %2. Do variable: %3.", _unitClass, _trgt, _doVariable];
 if(random 100 < 6)then{
 	[] execFSM "\x\addons\a3_epoch_code\System\Event_Air_Drop.fsm";
 };
+if(_doVariable)then{_unitClass call EPOCH_unitSpawnIncrease;};//Assumes Antagonist is required.
 
 _index = EPOCH_spawnIndex find _unitClass;
-if (count(player nearEntities[_unitClass, 800]) >= (EPOCH_playerSpawnArray select _index)) exitWith{};
+if (!_doVariable && (count(_trgt nearEntities[_unitClass, 800]) >= (EPOCH_playerSpawnArray select _index))) exitWith{};
 
 _nonJammer = ["CfgEpochClient", "nonJammerAI", ["B_Heli_Transport_01_F","PHANTOM","Epoch_Cloak_F"]] call EPOCH_fnc_returnConfigEntryV2;
 _nonTrader = ["CfgEpochClient", "nonTraderAI", ["B_Heli_Transport_01_F","PHANTOM","Epoch_Cloak_F","GreatWhite_F"]] call EPOCH_fnc_returnConfigEntryV2;
@@ -28,18 +32,22 @@ _nonTraderAIRange = ["CfgEpochClient", "nonTraderAIRange", 150] call EPOCH_fnc_r
 
 _unit = objNull;
 
-_targetPos = getPosATL player;
+_targetPos = getPosATL _trgt;
 _targetPos set [2,0];
 
 _jammers = [];
 _config = 'CfgEpochClient' call EPOCH_returnConfig;
 _jammerRange = getNumber(_config >> "buildingJammerRange");
 _jammers = nearestObjects[_targetPos, ["PlotPole_EPOCH"], _jammerRange];
-if(count _jammers > 0 && (_unitClass in _nonJammer))exitWith{};
+if(count _jammers > 0 && !(_unitClass in _nonJammer))exitWith{
+if(_doVariable)then{["<t size='1.6' color='#99ffffff'>Not allowed near a base - Please respawn !</t>", 5] call Epoch_dynamicText;};
+};
 
 _restricted = [];
 _restricted = nearestObjects [_targetPos, ["ProtectionZone_Invisible_F"], _nonTraderAIRange];
-if(count _restricted > 0 && (_unitClass in _nonTrader))exitWith{};
+if(count _restricted > 0 && !(_unitClass in _nonTrader))exitWith{
+if(_doVariable)then{["<t size='1.6' color='#99ffffff'>Not allowed near a trader - Please respawn !</t>", 5] call Epoch_dynamicText;};
+};
 
 _disableAI = {
 	{_this disableAI _x}forEach["TARGET","AUTOTARGET","FSM"];
@@ -49,11 +57,11 @@ switch _unitClass do {
 	case "Epoch_Cloak_F": {
 		_unit = createAgent[_unitClass, _targetPos, [], 256, "FORM"];
 		_unit call _disableAI;
-		[_unit] execFSM "\x\addons\a3_epoch_code\System\cloak.fsm";
+		[_unit,_trgt] execFSM "\x\addons\a3_epoch_code\System\cloak.fsm";
 	};
 	case "GreatWhite_F": {
 		if (surfaceIsWater _targetPos) then{
-			if (((_targetPos vectorDiff getPosASL player) select 2) > 25) then{
+			if (((_targetPos vectorDiff getPosASL _trgt) select 2) > 25) then{
 				_unit = createAgent[_unitClass, _targetPos, [], 120, "FORM"];
 				_unit call _disableAI;
 				[_unit] execFSM "\x\addons\a3_epoch_code\System\Shark_Brain.fsm";
@@ -61,19 +69,19 @@ switch _unitClass do {
 		};
 	};
 	case "Epoch_Sapper_F": {
-		if(random 100 < 6)then{
+		if(random 100 < 6 && isNull _trgt)then{
 			_config = 'CfgEpochSapper' call EPOCH_returnConfig;
 			_sapperNum = 8;
 			if(getNumber(_config >> "sapperMigrationCount") > 0)then{
 				_sapperNum = getNumber(_config >> "sapperMigrationCount");
 			};
-			[player,_sapperNum] execVM "epoch_code\compile\EPOCH_callSapperMigration.sqf";
+			[_trgt,_sapperNum] execVM "epoch_code\compile\EPOCH_callSapperMigration.sqf";
 		}else{
 			_unit = createAgent[_unitClass, _targetPos, [], 256, "FORM"];
 			_bomb = createVehicle ["Sapper_Charge_Ammo", _targetPos, [], 0, "CAN_COLLIDE"];
 			_bomb attachTo [_unit, [0,0,0],"Pelvis"];
 			_unit call _disableAI;
-			sapperHndl = [_unit, _bomb] execFSM "\x\addons\a3_epoch_code\System\Sapper_Brain.fsm";
+			sapperHndl = [_unit, _bomb, _trgt] execFSM "\x\addons\a3_epoch_code\System\Sapper_Brain.fsm";
 			_unit addEventHandler ["FiredNear", "sapperHndl setFSMVariable [""_sFiredNear"",[_this select 1, _this select 2]];"];
 			_unit addEventHandler ["Hit", "sapperHndl setFSMVariable [""_sHit"",[_this select 1, _this select 2]];"];
 		};
@@ -83,12 +91,12 @@ switch _unitClass do {
 		_bomb = createVehicle["SapperB_Charge_Ammo", _targetPos, [], 0, "CAN_COLLIDE"];
 		_bomb attachTo[_unit, [0, 0, 0], "Pelvis"];
 		_unit call _disableAI;
-		sapperHndl = [_unit, _bomb] execFSM "\x\addons\a3_epoch_code\System\Sapper_Brain2.fsm";
+		sapperHndl = [_unit, _bomb, _trgt] execFSM "\x\addons\a3_epoch_code\System\Sapper_Brain2.fsm";
 		_unit addEventHandler["FiredNear", "sapperHndl setFSMVariable [""_sFiredNear"",[_this select 1, _this select 2]];"];
 		_unit addEventHandler["Hit", "sapperHndl setFSMVariable [""_sHit"",[_this select 1, _this select 2]];"];
 	};
 	case "I_UAV_01_F": {
-		_targetPos = getPosATL player;
+		_targetPos = getPosATL _trgt;
 		_targetPos = [_targetPos, 600, 1200, 5, 0, 400, 0] call BIS_fnc_findSafePos;
 		_targetPos set[2, 600];
 		_unit = createVehicle["I_UAV_01_F", _targetPos, [], 0, "FLY"];
@@ -97,7 +105,7 @@ switch _unitClass do {
 		_grp = createGroup RESISTANCE;
 		_driver = _grp createUnit["I_UAV_AI", position _unit, [], 0, "CAN_COLLIDE"];
 		_driver moveInAny _unit;
-		[_unit, player] execFSM "\x\addons\a3_epoch_code\System\Copter_brain.fsm";
+		[_unit, _trgt] execFSM "\x\addons\a3_epoch_code\System\Copter_brain.fsm";
 	};
 	case "PHANTOM": {
 		[] execFSM "\x\addons\a3_epoch_code\System\Phantom_Brain.fsm";
@@ -107,6 +115,12 @@ switch _unitClass do {
 	};
 };
 
+if(_doVariable && (!isNull _unit) && (!isNull _trgt))then{
+_trgt setVariable ["EPOCH_antagObj", _unit, true];
+if!(isNull _bomb)then{
+_trgt setVariable ["EPOCH_antagBomb", _bomb, true];
+};
+};
 if !(isNull _unit) then {
 	// send to server
 	[_unit] remoteExec ["EPOCH_localCleanup",2];

--- a/Sources/epoch_code/compile/functions/EPOCH_fnc_dirToFuzzy.sqf
+++ b/Sources/epoch_code/compile/functions/EPOCH_fnc_dirToFuzzy.sqf
@@ -4,7 +4,7 @@
     Contributors:
 
 	Description:
-	Epoch cursorTarget anywhere
+	Direction from one object to another plus a degree value to chose a random direction within.
 
     Licence:
     Arma Public License Share Alike (APL-SA) - https://www.bistudio.com/community/licenses/arma-public-license-share-alike
@@ -18,7 +18,7 @@
     Parameter(s):
 		_this select 0: (ARRAY or OBJECT) - position1
         _this select 1: (ARRAY or OBJECT) - position2
-        _this select 2: NUMBER - random spread [optional: default 32]
+        _this select 2: NUMBER - random spread [optional: default 32] max 360
 
 	Returns:
 	SCALAR - (direction 0-360)

--- a/Sources/epoch_code/compile/functions/EPOCH_fnc_playerAttachToAntagonist.sqf
+++ b/Sources/epoch_code/compile/functions/EPOCH_fnc_playerAttachToAntagonist.sqf
@@ -1,0 +1,65 @@
+/*
+	Author: Andrew Gregory - EpochMod.com
+
+    Contributors:
+
+	Description:
+	Switch player camera to antagonist. Currently only for use after player death. Return to player body when finished or revived.
+
+    Licence:
+    Arma Public License Share Alike (APL-SA) - https://www.bistudio.com/community/licenses/arma-public-license-share-alike
+
+    Github:
+    https://github.com/EpochModTeam/Epoch/tree/master/Sources/epoch_code/compile/functions/EPOCH_fnc_playerAttachToAntagonist.sqf
+
+    Example:
+    [_antagonistObj,_plyrObj] call EPOCH_fnc_playerAttachToAntagonist;
+
+    Parameter(s):
+	_this select 0: OBJECT - Antagonist Object
+	_this select 1: OBJECT - Player Object
+	
+	Returns:
+	
+*/
+params ["_player", "_antagonist", "_bomb","_killer"];
+private _tapDiag = "TapOut";
+if (visibleMap) then {openMap [false, true];};
+_antagonist switchCamera "Internal";
+if(isNil "_bomb")then{_bomb = objNull;};
+if(typeOf _antagonist == "Epoch_Sapper_F" || typeOf _antagonist == "Epoch_SapperB_F")then{_tapDiag = "TapOut3";};
+createDialog _tapDiag;
+
+diag_log format["Epoch: DEBUG: Attaching player %1 to %2, bomb found: %3",_player,_antagonist,_bomb];
+[_antagonist,_tapDiag,_player,_killer] spawn{
+_antagonist2 = _this select 0;
+_tapDiag2 = _this select 1;
+_player2 = _this select 2;
+_killer2 = _this select 3;
+private _doingGroan = false;
+private _doingBoom = false;
+private _groanTime = diag_tickTime;
+	while {!alive _player2} do {
+		if (playerRespawnTime <= 1) exitWith{ (findDisplay 46) closeDisplay 0; };
+		if (playerRespawnTime > 15 && !dialog) then {createDialog _tapDiag2;};
+		if (isObjectHidden _player2) exitWith {[_player2,Epoch_personalToken,_killer2, "EPOCH_antagObj", objNull, true] remoteExec ["EPOCH_server_playerSetVariable",2];closeDialog 2;};//revivial
+		if((!alive _antagonist2)) exitWith {
+		[_player2,Epoch_personalToken,_killer2, "EPOCH_antagObj", objNull, true] remoteExec ["EPOCH_server_playerSetVariable",2];
+		uiSleep 3;(findDisplay 46) closeDisplay 0;};
+		if(_player2 getVariable["EPOCH_callGroan",false])then{
+		_player2 setVariable["EPOCH_callGroan",false];
+		_doingGroan = true;
+		_groanTime = diag_tickTime;
+		[_player2,Epoch_personalToken,_killer2, "EPOCH_callGroan", true, false] remoteExec ["EPOCH_server_playerSetVariable",2];
+		};
+		if(_player2 getVariable["EPOCH_callBoom",false])then{
+		_player2 setVariable["EPOCH_callBoom",false];
+		_doingBoom = true;
+		[_player2,Epoch_personalToken,_killer2, "EPOCH_callBoom", true, false] remoteExec ["EPOCH_server_playerSetVariable",2];
+		};
+		if(_doingGroan && ctrlEnabled 1602)then{ctrlEnable[1602,false];};
+		if(_doingGroan && !(ctrlEnabled 1602) && diag_tickTime - _groanTime > 16)then{ctrlEnable[1602,true];_doingGroan=false;};
+		if(_doingBoom && ctrlEnabled 1601)then{ctrlEnable[1601,false];};
+		uiSleep 0.1;
+	};
+};

--- a/Sources/epoch_code/compile/functions/EPOCH_fnc_playerDeath.sqf
+++ b/Sources/epoch_code/compile/functions/EPOCH_fnc_playerDeath.sqf
@@ -1,7 +1,7 @@
 /*
 	Author: Aaron Clark - EpochMod.com
 
-    Contributors:
+    Contributors: Andrew Gregory
 
 	Description:
 	Player death handler
@@ -22,6 +22,8 @@
 	Returns:
 	BOOL
 */
+private _tapDiag = "TapOut";
+private _doRevenge = false;
 params ["_unit", "_killer"];
 
 // test ejecting unit from vehicle if dead client side
@@ -36,21 +38,26 @@ EPOCH_buildMode = 0;
 EPOCH_snapDirection = 0;
 EPOCH_Target = objNull;
 
+if(player != _killer && (isPlayer _killer || isPlayer (effectiveCommander _killer)))then{_tapDiag = "TapOut2";};//TODO: vehicle check may not always be reliable
+
 if (Epoch_canBeRevived) then {
 	setPlayerRespawnTime 600;
-	createDialog "TapOut";
+	createDialog _tapDiag;
 } else {
 	setPlayerRespawnTime 15;
 	["<t size='1.6' color='#99ffffff'>You can be just revived once per life!</t>", 5] call Epoch_dynamicText;
 };
 
-[] spawn{
+[_killer, _tapDiag] spawn{
+	_killer2 = _this select 0;
+	_tapDiag2 = _this select 1;
 	while {!alive player} do {
 
 		if (playerRespawnTime <= 1) exitWith{ (findDisplay 46) closeDisplay 0; };
-		if (playerRespawnTime > 15 && !dialog) then {
-			createDialog "TapOut";
-		};
+		if (playerRespawnTime > 15 && !dialog) then {createDialog _tapDiag2;};
+		if (isObjectHidden player) then {closeDialog 2;};
+		if(player getVariable["EPOCH_doBoom",false])exitWith{player setVariable ["EPOCH_doBoom",nil];[player] call EPOCH_fnc_playerDeathDetonate;};
+		if(player getVariable["EPOCH_doMorph",false])exitWith{player setVariable ["EPOCH_doMorph",nil];[selectRandom (getArray (getMissionConfig "CfgEpochClient" >> "deathMorphClass")),player,_killer2] call EPOCH_fnc_playerDeathMorph;};
 		uiSleep 0.1;
 	};
 };

--- a/Sources/epoch_code/compile/functions/EPOCH_fnc_playerDeathDetonate.sqf
+++ b/Sources/epoch_code/compile/functions/EPOCH_fnc_playerDeathDetonate.sqf
@@ -1,0 +1,36 @@
+/*
+	Author: Andrew Gregory - EpochMod.com
+
+    Contributors:
+
+	Description:
+	Detonate player body.
+
+    Licence:
+    Arma Public License Share Alike (APL-SA) - https://www.bistudio.com/community/licenses/arma-public-license-share-alike
+
+    Github:
+    https://github.com/EpochModTeam/Epoch/tree/master/Sources/epoch_code/compile/functions/EPOCH_fnc_playerDeathDetonate.sqf
+
+    Example:
+    [] call EPOCH_fnc_playerDeathDetonate;
+
+    Parameter(s):
+
+	Returns:
+	BOOM
+*/
+params ["_player"];
+openmap [false,false];
+closeDialog 2;
+[_player, Epoch_personalToken] remoteExec ["EPOCH_server_deadPlayerDetonate",2];
+deleteVehicle player;
+player setVariable ["doneBoom", true];
+
+[] spawn{
+	while {!alive player} do {
+	//Handle clean up
+		if(player getVariable["doneBoom",false])exitWith{player setVariable ["doneBoom",nil]; uiSleep 5; (findDisplay 46) closeDisplay 0;};
+		uiSleep 0.1;
+	};
+};

--- a/Sources/epoch_code/compile/functions/EPOCH_fnc_playerDeathMorph.sqf
+++ b/Sources/epoch_code/compile/functions/EPOCH_fnc_playerDeathMorph.sqf
@@ -1,0 +1,38 @@
+/*
+	Author: Andrew Gregory - EpochMod.com
+
+    Contributors:
+
+	Description:
+	Morph dead player body into an antagonist, called from player death GUI. Dead player camera will attach to antagonist.
+
+    Licence:
+    Arma Public License Share Alike (APL-SA) - https://www.bistudio.com/community/licenses/arma-public-license-share-alike
+
+    Github:
+    https://github.com/EpochModTeam/Epoch/tree/master/Sources/epoch_code/compile/functions/EPOCH_fnc_playerDeathMorph.sqf
+
+    Example:
+    [] call EPOCH_fnc_playerDeathMorph;
+
+    Parameter(s):
+	_this select 0: STRING - Antagonist class
+	_this select 1: OBJECT - Player (Victim)
+	_this select 2: OBJECT - Target Player (Killer)
+
+	Returns:
+*/
+params ["_antagonistClass", "_player", "_killer"];
+
+openmap [false,false];
+[_killer,_antagonistClass,true,_player, Epoch_personalToken] remoteExec ["EPOCH_server_triggerAntagonist",2];
+
+[_killer,_player] spawn{
+_killer2 = _this select 0;
+_player2 = _this select 1;
+	while {!alive player} do {
+		if (isObjectHidden _player2) then {closeDialog 2;};
+		if!(isNull (_killer2 getVariable["EPOCH_antagObj",objNull])) exitWith {closeDialog 2;[_player2,(_killer2 getVariable["EPOCH_antagObj",objNull]),(_killer2 getVariable["EPOCH_antagBomb",objNull]),_killer2] call EPOCH_fnc_playerAttachToAntagonist;};
+		uiSleep 0.1;
+	};
+};

--- a/Sources/epoch_code/compile/functions/EPOCH_fnc_playerSetVariable.sqf
+++ b/Sources/epoch_code/compile/functions/EPOCH_fnc_playerSetVariable.sqf
@@ -1,0 +1,30 @@
+/*
+	Author: Andrew Gregory - EpochMod.com
+
+    Contributors:
+
+	Description:
+	call setVariable from client. Allows the server to call and set a local variable on an object via a player without broadcasting.
+
+    Licence:
+    Arma Public License Share Alike (APL-SA) - https://www.bistudio.com/community/licenses/arma-public-license-share-alike
+
+    Github:
+    https://github.com/EpochModTeam/Epoch/tree/master/Sources/epoch_code/compile/functions/EPOCH_fnc_playerSetVariable.sqf
+
+    Example:
+    [_obj,_var,_value,_local] call EPOCH_fnc_playerSetVariable;
+
+    Parameter(s):
+		_this select 0: OBJECT - Object to attach variable to
+        _this select 1: STRING - Variable Name
+		_this select 2: ANYTHING - Variable Value
+        _this select 3: BOOLEAN - Broadcast ?
+	Returns:
+
+*/
+
+params ["_obj", "_var", "_value", "_local"];
+if(isNil "_local")then{_local = false;};
+diag_log format["Epoch: ADMIN: Attempting Set variable [%2,%3,%4] on %1.", _obj, _var, _value,_local];
+_obj setVariable [_var,_value,_local];

--- a/Sources/epoch_code/compile/functions/EPOCH_fnc_triggerAntagonist.sqf
+++ b/Sources/epoch_code/compile/functions/EPOCH_fnc_triggerAntagonist.sqf
@@ -1,0 +1,27 @@
+/*
+	Author: Andrew Gregory - EpochMod.com
+
+    Contributors: Aaron Clark
+
+	Description:
+	Send server message to trigger antagonist on another client. Server returns antagonist object where required. Designed to support additional tap out options (Morphing).
+
+    Licence:
+    Arma Public License Share Alike (APL-SA) - https://www.bistudio.com/community/licenses/arma-public-license-share-alike
+
+    Github:
+    https://github.com/EpochModTeam/Epoch/tree/master/Sources/epoch_code/compile/functions/EPOCH_fnc_triggerAntagonist.sqf
+
+    Example:
+    [_killer, "Epoch_Sapper_F", player, true] call EPOCH_fnc_triggerAntagonist;
+
+    Parameter(s):
+		_this select 0: Target client to trigger antagonist on. (Killer)
+		_this select 1: Antagonist class to spawn, e.g. "Epoch_Sapper_F", see EPOCH_unitSpawn.sqf for full list
+        _this select 2: On target, set variable containing antagonist object. Allows other players / requesting player to attach to antagonist object.
+        
+	Returns:
+	
+*/
+params ["_target","_antagonist","_doVariable"];
+[_target,_antagonist,_doVariable,player,Epoch_personalToken] remoteExec ["EPOCH_server_triggerAntagonist",2];

--- a/Sources/epoch_config/Configs/CfgEpochClient.hpp
+++ b/Sources/epoch_config/Configs/CfgEpochClient.hpp
@@ -58,22 +58,24 @@ class CfgEpochClient
 
 	// Event handler code
 	displayAddEventHandler[] = {"keyDown","keyUp"};
-    keyDown = "(_this call EPOCH_KeyDown)";
-    keyUp   = "(_this call EPOCH_KeyUp)";
-	addEventHandler[] = {"Respawn","Put","Take","InventoryClosed","InventoryOpened","Fired","Killed","HandleRating"};
+    	keyDown = "(_this call EPOCH_KeyDown)";
+    	keyUp   = "(_this call EPOCH_KeyUp)";
+	addEventHandler[] = {"Respawn","Put","Take","InventoryClosed","InventoryOpened","Fired","Killed","HandleRating","GetInMan","GetOutMan"};
 	Respawn = "(_this select 0) call EPOCH_clientRespawn";
 	Put = "(_this select 1) call EPOCH_interact;_this call EPOCH_PutHandler";
   	Take = "(_this select 1) call EPOCH_interact;_this call EPOCH_UnisexCheck";
-    Fired           = "_this call EPOCH_fnc_playerFired;";
-    InventoryClosed = "if !(EPOCH_arr_interactedObjs isEqualTo[]) then {[EPOCH_arr_interactedObjs] remoteExec['EPOCH_server_save_vehicles', 2]; EPOCH_arr_interactedObjs = [];};";
+    	Fired           = "_this call EPOCH_fnc_playerFired;";
+    	InventoryClosed = "if !(EPOCH_arr_interactedObjs isEqualTo[]) then {[EPOCH_arr_interactedObjs] remoteExec['EPOCH_server_save_vehicles', 2]; EPOCH_arr_interactedObjs = [];};";
 	InventoryOpened = "_this spawn EPOCH_initUI;_container = _this select 1;_lockedNear = false;if (_container isKindOf 'GroundWeaponHolder' || _container isKindOf 'WeaponHolderSimulated') then {{if (locked _x in [2, 3] ||_x getVariable['EPOCH_Locked', false]) exitWith {_lockedNear = true}} forEach (player nearSupplies 10);};if (locked _container in [2, 3] || _container getVariable['EPOCH_Locked', false] || _lockedNear) then {[] spawn {disableSerialization;waitUntil {!isNull findDisplay 602};_display = findDisplay 602;_ctrl_cargo = _display displayCtrl 6401;_ctrl_ground = _display displayCtrl 6321;_ctrl_cargo ctrlEnable  false;ctrlSetFocus _ctrl_ground;ctrlActivate _ctrl_ground;};};";
-    Killed          = "_this call EPOCH_fnc_playerDeath;";
+	Killed          = "_this call EPOCH_fnc_playerDeath;";
 	HandleRating    = "EPOCH_playerKarma = EPOCH_playerKarma + (_this select 1);0";
 	HandleDamage    = "";
 	HandleHeal      = "";
 	Dammaged        = "";
 	Hit             = "";
 	HitPart         = "";
+ 	GetInMan        = "";
+ 	GetOutMan       = "_this call EPOCH_antiWall;";
 
 	// suppress these units from spawning near Jammer or Traders
 	nonJammerAI[] = {"B_Heli_Transport_01_F","PHANTOM","Epoch_Cloak_F"};

--- a/Sources/epoch_config/Configs/CfgEpochClient.hpp
+++ b/Sources/epoch_config/Configs/CfgEpochClient.hpp
@@ -58,14 +58,14 @@ class CfgEpochClient
 
 	// Event handler code
 	displayAddEventHandler[] = {"keyDown","keyUp"};
-    	keyDown = "(_this call EPOCH_KeyDown)";
-    	keyUp   = "(_this call EPOCH_KeyUp)";
+	keyDown = "(_this call EPOCH_KeyDown)";
+	keyUp   = "(_this call EPOCH_KeyUp)";
 	addEventHandler[] = {"Respawn","Put","Take","InventoryClosed","InventoryOpened","Fired","Killed","HandleRating","GetInMan","GetOutMan"};
 	Respawn = "(_this select 0) call EPOCH_clientRespawn";
 	Put = "(_this select 1) call EPOCH_interact;_this call EPOCH_PutHandler";
-  	Take = "(_this select 1) call EPOCH_interact;_this call EPOCH_UnisexCheck";
-    	Fired           = "_this call EPOCH_fnc_playerFired;";
-    	InventoryClosed = "if !(EPOCH_arr_interactedObjs isEqualTo[]) then {[EPOCH_arr_interactedObjs] remoteExec['EPOCH_server_save_vehicles', 2]; EPOCH_arr_interactedObjs = [];};";
+	Take = "(_this select 1) call EPOCH_interact;_this call EPOCH_UnisexCheck";
+	Fired           = "_this call EPOCH_fnc_playerFired;";
+	InventoryClosed = "if !(EPOCH_arr_interactedObjs isEqualTo[]) then {[EPOCH_arr_interactedObjs] remoteExec['EPOCH_server_save_vehicles', 2]; EPOCH_arr_interactedObjs = [];};";
 	InventoryOpened = "_this spawn EPOCH_initUI;_container = _this select 1;_lockedNear = false;if (_container isKindOf 'GroundWeaponHolder' || _container isKindOf 'WeaponHolderSimulated') then {{if (locked _x in [2, 3] ||_x getVariable['EPOCH_Locked', false]) exitWith {_lockedNear = true}} forEach (player nearSupplies 10);};if (locked _container in [2, 3] || _container getVariable['EPOCH_Locked', false] || _lockedNear) then {[] spawn {disableSerialization;waitUntil {!isNull findDisplay 602};_display = findDisplay 602;_ctrl_cargo = _display displayCtrl 6401;_ctrl_ground = _display displayCtrl 6321;_ctrl_cargo ctrlEnable  false;ctrlSetFocus _ctrl_ground;ctrlActivate _ctrl_ground;};};";
 	Killed          = "_this call EPOCH_fnc_playerDeath;";
 	HandleRating    = "EPOCH_playerKarma = EPOCH_playerKarma + (_this select 1);0";
@@ -74,8 +74,8 @@ class CfgEpochClient
 	Dammaged        = "";
 	Hit             = "";
 	HitPart         = "";
- 	GetInMan        = "";
- 	GetOutMan       = "_this call EPOCH_antiWall;";
+	GetInMan        = "";
+	GetOutMan       = "_this call EPOCH_antiWall;";
 
 	// suppress these units from spawning near Jammer or Traders
 	nonJammerAI[] = {"B_Heli_Transport_01_F","PHANTOM","Epoch_Cloak_F"};

--- a/Sources/epoch_config/Configs/CfgEpochClient.hpp
+++ b/Sources/epoch_config/Configs/CfgEpochClient.hpp
@@ -1,6 +1,6 @@
 /*
 	Author: Aaron Clark - EpochMod.com
-    Contributors:
+    Contributors: Andrew Gregory
 
 	Description:
 	Main Client side configs for the Epoch gamemode
@@ -23,6 +23,7 @@ class CfgEpochClient
 	buildingJammerRange = 75; // jammer range in meters
 	disableRemoteSensors = true; // disableRemoteSensors true
 	EPOCH_news[] = {"Word is that Sappers have a new boss.","Dogs will often lure them monsters away.","My dog was blown up. I miss him.."};
+	deathMorphClass[] = {"Epoch_Sapper_F","Epoch_SapperB_F","I_UAV_01_F","Epoch_Cloak_F"};//Random selection of these classes when player morphs after death. Currently available: Epoch_Cloak_F, Epoch_SapperB_F, Epoch_Sapper_F, I_UAV_01_F
 	antagonistSpawnIndex[] = {
 		{"Epoch_Cloak_F", 1}, // {"type", limit}
 		{"GreatWhite_F", 2},
@@ -59,7 +60,7 @@ class CfgEpochClient
 	displayAddEventHandler[] = {"keyDown","keyUp"};
     keyDown = "(_this call EPOCH_KeyDown)";
     keyUp   = "(_this call EPOCH_KeyUp)";
-	addEventHandler[] = {"Respawn","Put","Take","InventoryClosed","InventoryOpened","Fired","Killed","HandleRating","GetInMan","GetOutMan"};
+	addEventHandler[] = {"Respawn","Put","Take","InventoryClosed","InventoryOpened","Fired","Killed","HandleRating"};
 	Respawn = "(_this select 0) call EPOCH_clientRespawn";
 	Put = "(_this select 1) call EPOCH_interact;_this call EPOCH_PutHandler";
   	Take = "(_this select 1) call EPOCH_interact;_this call EPOCH_UnisexCheck";
@@ -73,8 +74,6 @@ class CfgEpochClient
 	Dammaged        = "";
 	Hit             = "";
 	HitPart         = "";
-	GetInMan        = "";
-	GetOutMan       = "_this call EPOCH_antiWall;";
 
 	// suppress these units from spawning near Jammer or Traders
 	nonJammerAI[] = {"B_Heli_Transport_01_F","PHANTOM","Epoch_Cloak_F"};
@@ -108,12 +107,32 @@ class CfgEpochSapper
 	groanTrig = 16; //Percentage chance of a groan. Min value = 4
 	sRange = 300; //Distance from target over which sapper will dispose. Range within which sapper code will be aware of targets. Distance up to which sapper will attempt to find a spot to hide in. Min Value = 150.
 	smellDist = 24; //Distance up to which sapper can smell. Used to decide if sapper can see target when deciding to charge and influences target selection. Is influenced by wind direction. Min Value = 8.
+	reflexSpeed = 0.25; //Sapper brain will pause for this time when checking for new stimulus during each thought process. Lower number equals a more reactive sapper. (Guide Min 0.25 - Max 2.5).
+	nestChance = 2; //Every time a sapper spawns apply this percentage chance that sapper will create a nest.
+	hideLevel = 72; //(Emotion) Sapper fear increases by several factors, higher number of armed player(s) in area / being shot at. Set fear level (out of 100) at which he will go into a 'hide / evade mode'.. temporarily.
+	chargeLevel = 52; //(Emotion) Sapper anger increases by smelling / sensing players, being shot at / hit, too many players on his turf. Set level (Out of 100) at which he is triggered to charge on the current target.
 };
 class CfgEpochUAV
 {
 	UAVMinDist = 48; //Minimum distance to choose next position when roaming. Min Value = 8.
 	UAVMaxDist = 180; //Maximum distance to choose next position when roaming. Min Value = 42 / Max Value = 400.
 	UAVHeight = 100; //Set height when roaming, slight randomness is applied to this value. UAV will choose own height when locked onto target. Min Value = 42 / Max Value = 280. UAV can still spot targets from height !
+};
+class CfgEpochUAVSupport
+{
+	unitTypes[] = {"I_Soldier_EPOCH", "I_Soldier2_EPOCH", "I_Soldier3_EPOCH"};//Selects from randomly
+	maxUnitNum = 2; //Maximum number of units spawned when UAV spots target.
+	minAISkill = 0.2; //Minumum AI Skill. Skills are chosen randomly between this minimum overall AI skill value and the following max AI skill values, for each of the next skills:
+	maxAimingAccuracy = 0.7;
+	maxAimingShake = 0.9;
+	maxAimingSpeed = 0.6;
+	maxEndurance = 0.4;
+	maxSpotDistance = 0.4;
+	maxSpotTime = 0.3;
+	maxCourage = 0.3;
+	maxReloadSpeed = 0.5;
+	maxCommanding = 0.4;
+	maxGeneral = 0.4;
 };
 class CfgEpochAirDrop
 {

--- a/Sources/epoch_config/Configs/CfgRemoteExec.hpp
+++ b/Sources/epoch_config/Configs/CfgRemoteExec.hpp
@@ -1,7 +1,7 @@
 /*
 	Author: Aaron Clark - EpochMod.com
 
-    Contributors:
+    Contributors: Andrew Gregory
 
 	Description:
 	RemoteExec whitelist for Epoch sandbox gamemode. This also blacklists default A3 remoteExec commands.
@@ -197,6 +197,19 @@ class CfgRemoteExec
       allowedTargets=2;
       jip = 0;
     };
+	class EPOCH_server_triggerAntagonist {
+      allowedTargets=2;
+      jip = 0;
+    };
+	class EPOCH_server_deadPlayerDetonate {
+      allowedTargets=2;
+      jip = 0;
+    };
+	class epoch_server_playersetvariable {
+      allowedTargets=2;
+      jip = 0;
+    };
+	
   };
   class Commands {mode=0;};
 };

--- a/Sources/epoch_server/compile/epoch_antagonists/EPOCH_server_triggerAntagonist.sqf
+++ b/Sources/epoch_server/compile/epoch_antagonists/EPOCH_server_triggerAntagonist.sqf
@@ -1,0 +1,24 @@
+/*
+	Author: Andrew Gregory - EpochMod.com
+
+    Contributors: Aaron Clark
+
+	Description:
+    Trigger an antagonist on a client. Option to add antagonist object to target as a variable.
+
+    Licence:
+    Arma Public License Share Alike (APL-SA) - https://www.bistudio.com/community/licenses/arma-public-license-share-alike
+
+    Github:
+    https://github.com/EpochModTeam/Epoch/tree/master/Sources/epoch_server/compile/epoch_antagonists/EPOCH_server_triggerAntagonist.sqf
+*/
+params ["_target","_antagonistClass","_doVariable","_player","_token"];
+diag_log format["Epoch: ADMIN: Attempting antagonist (%3) trigger from %1 for %2.", getPlayerUID _player, _target, _antagonistClass];
+if !([_player,_token]call EPOCH_server_getPToken)exitWith{};
+
+if(!isNull _target)then{
+diag_log format["Epoch: ADMIN: Calling antagonist (%3) trigger from %1 for %2.", getPlayerUID _player, _target, _antagonistClass];
+
+[_antagonistClass, _target, _doVariable] remoteExec ["EPOCH_unitSpawn",_target];
+//if(!isNull _player)then{hideObjectGlobal _player;};//Do elsewhere, allow revival
+};

--- a/Sources/epoch_server/compile/epoch_missions/EPOCH_Server_airDropCrate.sqf
+++ b/Sources/epoch_server/compile/epoch_missions/EPOCH_Server_airDropCrate.sqf
@@ -1,7 +1,7 @@
 /*
-	Author: Aaron Clark - EpochMod.com
+	Author: Andrew Gregory - EpochMod.com
 
-    Contributors:
+    Contributors: Aaron Clark
 
 	Description:
 	Creates air drop crate

--- a/Sources/epoch_server/compile/epoch_missions/EPOCH_Server_createAirDrop.sqf
+++ b/Sources/epoch_server/compile/epoch_missions/EPOCH_Server_createAirDrop.sqf
@@ -1,7 +1,7 @@
 /*
-	Author: Aaron Clark - EpochMod.com
+	Author: Andrew Gregory - EpochMod.com
 
-    Contributors:
+    Contributors: Aaron Clark
 
 	Description:
 	Creates helicopter air drop

--- a/Sources/epoch_server/compile/epoch_missions/EPOCH_Server_createObject.sqf
+++ b/Sources/epoch_server/compile/epoch_missions/EPOCH_Server_createObject.sqf
@@ -1,7 +1,7 @@
 /*
-	Author: Aaron Clark - EpochMod.com
+	Author: Andrew Gregory - EpochMod.com
 
-    Contributors:
+    Contributors: Aaron Clark
 
 	Description:
 	Server side spawing of shipwreck loots

--- a/Sources/epoch_server/compile/epoch_player/EPOCH_server_deadPlayerDetonate.sqf
+++ b/Sources/epoch_server/compile/epoch_player/EPOCH_server_deadPlayerDetonate.sqf
@@ -1,0 +1,22 @@
+/*
+	Author: Andrew Gregory - EpochMod.com
+
+    Contributors: Aaron Clark
+
+	Description:
+    Detonate a boss sapper bomb at player position.
+
+    Licence:
+    Arma Public License Share Alike (APL-SA) - https://www.bistudio.com/community/licenses/arma-public-license-share-alike
+
+    Github:
+    https://github.com/EpochModTeam/Epoch/tree/master/Sources/epoch_server/compile/epoch_antagonists/EPOCH_server_playerDeathOptions.sqf
+*/
+params ["_player", "_token"];
+diag_log format["Epoch: ADMIN: Attempting player detonate on %1.", getPlayerUID _player];
+if !([_player,_token]call EPOCH_server_getPToken)exitWith{};
+
+_pos = getPosATL _player;
+_bomb = createVehicle["SapperB_Charge_Ammo", _pos, [], 0, "CAN_COLLIDE"];
+_bomb setDamage 1;
+hideObjectGlobal _player;

--- a/Sources/epoch_server/compile/epoch_player/EPOCH_server_playerSetVariable.sqf
+++ b/Sources/epoch_server/compile/epoch_player/EPOCH_server_playerSetVariable.sqf
@@ -1,0 +1,18 @@
+/*
+	Author: Andrew Gregory - EpochMod.com
+
+    Contributors:
+
+	Description:
+    Call setVariable on specific client.
+
+    Licence:
+    Arma Public License Share Alike (APL-SA) - https://www.bistudio.com/community/licenses/arma-public-license-share-alike
+
+    Github:
+    https://github.com/EpochModTeam/Epoch/tree/master/Sources/epoch_server/compile/epoch_antagonists/EPOCH_server_playerSetVariable.sqf
+*/
+params ["_player","_token","_obj", "_var", "_value", "_local"];
+if !([_player,_token]call EPOCH_server_getPToken)exitWith{};
+diag_log format["Epoch: ADMIN: Attempting Set variable [%2,%3,%4] on %1.", _obj, _var, _value,_local];
+[_obj, _var,_value,_local] remoteExec ['EPOCH_fnc_playerSetVariable', _obj];

--- a/Sources/epoch_server/config.cpp
+++ b/Sources/epoch_server/config.cpp
@@ -1,21 +1,16 @@
-////////////////////////////////////////////////////////////////////
-//DeRap: Produced from mikero's Dos Tools Dll version 4.90
-//Tue Apr 19 09:31:41 2016 : Source 'file' date Tue Apr 19 09:31:41 2016
-//http://dev-heaven.net/projects/list_files/mikero-pbodll
-////////////////////////////////////////////////////////////////////
+/****************************************************************************
+Copyright (C) 2015 - ARMA 3 EPOCH MOD [EpochMod.com] (v0.3.0.1)
+*****************************************************************************/
 
 #define _ARMA_
 
-//Class C:\arma3server\@epochhive\addons\a3_epoch_server\config.bin{
-class CfgPatches
-{
-	class A3_epoch_server
-	{
+class CfgPatches {
+	class A3_epoch_server {
 		units[] = {};
 		weapons[] = {};
 		requiredVersion = 0.1;
 		requiredAddons[] = {"A3_epoch_server_core","A3_epoch_config","A3_server_settings"};
-		build = 315;
+		#include "build.hpp"
 	};
 };
 class cfgFunctions
@@ -44,110 +39,100 @@ class CfgServerFunctions
 	{
 		tag = "EPOCH";
 		file = "\x\addons\a3_epoch_server\compile";
-		class epoch_group
-		{
-			class server_upgradeGroup{};
-			class server_updatePlayerGroup{};
-			class server_createGroup{};
-			class server_deleteGroup{};
-			class server_invitePlayer{};
+		class epoch_group {
+			class server_upgradeGroup {};
+			class server_updatePlayerGroup {};
+			class server_createGroup {};
+			class server_deleteGroup {};
+			class server_invitePlayer {};
 		};
-		class epoch_bases
-		{
-			class saveBuilding{};
-			class server_loadBuildings{};
-			class server_saveBuilding{};
-			class server_upgradeBUILD{};
-			class server_removeBUILD{};
-			class server_paintBUILD{};
-			class server_maintBUILD{};
-			class server_simulSwap{};
-			class server_simToStatic{};
-			class server_unsuppported{};
+		class epoch_bases {
+			class saveBuilding {};
+			class server_loadBuildings {};
+			class server_saveBuilding {};
+			class server_upgradeBUILD {};
+			class server_removeBUILD {};
+			class server_paintBUILD {};
+			class server_maintBUILD {};
+			class server_simulSwap {};
+			class server_simToStatic {};
+			class server_unsuppported {};
 		};
-		class epoch_looting
-		{
-			class server_lootContainer{};
-			class server_spawnBoatLoot{};
-			class server_destroyTrash{};
-			class server_knockDownTree{};
-			class server_mineRocks{};
-			class server_lootAnimal{};
+		class epoch_looting {
+			class server_lootContainer {};
+			class server_spawnBoatLoot {};
+			class server_destroyTrash {};
+			class server_knockDownTree {};
+			class server_mineRocks {};
+			class server_lootAnimal {};
 		};
-		class epoch_player
-		{
-			class fnc_savePlayer{};
-			class server_savePlayer{};
-			class server_loadPlayer{};
-			class server_checkPlayer{};
-			class server_onPlayerDisconnect{};
-			class server_deadPlayer{};
-			class server_revivePlayer{};
-			class server_storeCrypto{};
-			class server_equippedItem{};
-			class server_unpackBackpack{};
+		class epoch_player {
+			class fnc_savePlayer {};
+			class server_savePlayer {};
+			class server_loadPlayer {};
+			class server_checkPlayer {};
+			class server_onPlayerDisconnect {};
+			class server_deadPlayer {};
+			class server_revivePlayer {};
+			class server_storeCrypto {};
+			class server_equippedItem {};
+			class server_unpackBackpack {};
 			class server_deadPlayerDetonate{};
 			class server_playerSetVariable{};
 		};
-		class epoch_traders
-		{
-			class server_loadTraders{};
-			class server_spawnTraders{};
+		class epoch_traders {
+			class server_loadTraders {};
+			class server_spawnTraders {};
 		};
-		class epoch_trading
-		{
-			class server_makeTrade{};
-			class server_tradeRequest{};
-			class server_makeNPCTrade{};
-			class server_takeCrypto{};
+		class epoch_trading {
+			class server_makeTrade {};
+			class server_tradeRequest {};
+			class server_makeNPCTrade {};
+			class server_takeCrypto {};
 		};
-		class epoch_vehicle
-		{
-			class server_save_vehicles{};
-			class server_save_vehicle{};
-			class server_save_killedVehicle{};
-			class server_save_killedStorage{};
-			class server_save_killedBuilding{};
-			class load_vehicles{};
-			class load_storage{};
-			class server_save_storage{};
-			class spawn_vehicles{};
-			class server_lockVehicle{};
-			class server_fillVehicle{};
-			class server_repairVehicle{};
-			class server_lockStorage{};
-			class server_packStorage{};
-			class server_packJack{};
-			class spawn_vehicle{};
+		class epoch_vehicle {
+			class server_save_vehicles {};
+			class server_save_vehicle {};
+			class server_save_killedVehicle {};
+			class server_save_killedStorage {};
+			class server_save_killedBuilding {};
+			class load_vehicles {};
+			class load_storage {};
+			class server_save_storage {};
+			class spawn_vehicles {};
+			class server_lockVehicle {};
+			class server_fillVehicle {};
+			class server_repairVehicle {};
+			class server_lockStorage {};
+			class server_packStorage {};
+			class server_packJack {};
+			class spawn_vehicle {};
 		};
-		class epoch_server
-		{
-			class weightedArray{};
-			class precisionPos{};
-			class serverLootObject{};
-			class server_vehicleInit{};
-			class server_storageInit{};
-			class server_buildingInit{};
-			class server_traderKilled{};
-			class localCleanup{};
-			class server_createTeleport{};
-			class server_teleportPlayer{};
-			class returnConfig{};
-			class serverCommand{};
+		class epoch_server {
+			class weightedArray {};
+			class precisionPos {};
+			class serverLootObject {};
+			class server_vehicleInit {};
+			class server_storageInit {};
+			class server_buildingInit {};
+			class server_traderKilled {};
+			class localCleanup {};
+			class server_createTeleport {};
+			class server_teleportPlayer {};
+			class returnConfig {};
+			class serverCommand {};
 		};
-		class epoch_missions
-		{
-			class Server_createObject{};
-			class server_airDropCrate{};
-			class server_fillContainer{};
-			class Server_createAirDrop{};
+		class epoch_missions {
+			class Server_createObject {};
+			class server_airDropCrate {};
+			class server_fillContainer {};
+			class Server_createAirDrop {};
 		};
-		class epoch_antagonists
-		{
-			class server_triggerEvent{};
-			class server_handle_say3D{};
-			class server_handle_switchMove{};
-			class server_handle_sapperObjs{};
+		class epoch_antagonists {
+			class server_triggerEvent {};
+			class server_handle_say3D {};
+			class server_handle_switchMove {};
+			class server_handle_sapperObjs {};
 			class server_triggerAntagonist{};
 		};
 	};
@@ -158,9 +143,3 @@ class CfgServerVersion
 	config = "0.3.8.0";
 	hive = "0.5.1.7";
 };
-class cfgMods
-{
-	author = "";
-	timepacked = "1458312578";
-};
-//};

--- a/Sources/epoch_server/config.cpp
+++ b/Sources/epoch_server/config.cpp
@@ -1,16 +1,21 @@
-/****************************************************************************
-Copyright (C) 2015 - ARMA 3 EPOCH MOD [EpochMod.com] (v0.3.0.1)
-*****************************************************************************/
+////////////////////////////////////////////////////////////////////
+//DeRap: Produced from mikero's Dos Tools Dll version 4.90
+//Tue Apr 19 09:31:41 2016 : Source 'file' date Tue Apr 19 09:31:41 2016
+//http://dev-heaven.net/projects/list_files/mikero-pbodll
+////////////////////////////////////////////////////////////////////
 
 #define _ARMA_
 
-class CfgPatches {
-	class A3_epoch_server {
+//Class C:\arma3server\@epochhive\addons\a3_epoch_server\config.bin{
+class CfgPatches
+{
+	class A3_epoch_server
+	{
 		units[] = {};
 		weapons[] = {};
 		requiredVersion = 0.1;
 		requiredAddons[] = {"A3_epoch_server_core","A3_epoch_config","A3_server_settings"};
-		#include "build.hpp"
+		build = 315;
 	};
 };
 class cfgFunctions
@@ -39,99 +44,111 @@ class CfgServerFunctions
 	{
 		tag = "EPOCH";
 		file = "\x\addons\a3_epoch_server\compile";
-		class epoch_group {
-			class server_upgradeGroup {};
-			class server_updatePlayerGroup {};
-			class server_createGroup {};
-			class server_deleteGroup {};
-			class server_invitePlayer {};
+		class epoch_group
+		{
+			class server_upgradeGroup{};
+			class server_updatePlayerGroup{};
+			class server_createGroup{};
+			class server_deleteGroup{};
+			class server_invitePlayer{};
 		};
-		class epoch_bases {
-			class saveBuilding {};
-			class server_loadBuildings {};
-			class server_saveBuilding {};
-			class server_upgradeBUILD {};
-			class server_removeBUILD {};
-			class server_paintBUILD {};
-			class server_maintBUILD {};
-			class server_simulSwap {};
-			class server_simToStatic {};
-			class server_unsuppported {};
+		class epoch_bases
+		{
+			class saveBuilding{};
+			class server_loadBuildings{};
+			class server_saveBuilding{};
+			class server_upgradeBUILD{};
+			class server_removeBUILD{};
+			class server_paintBUILD{};
+			class server_maintBUILD{};
+			class server_simulSwap{};
+			class server_simToStatic{};
+			class server_unsuppported{};
 		};
-		class epoch_looting {
-			class server_lootContainer {};
-			class server_spawnBoatLoot {};
-			class server_destroyTrash {};
-			class server_knockDownTree {};
-			class server_mineRocks {};
-			class server_lootAnimal {};
+		class epoch_looting
+		{
+			class server_lootContainer{};
+			class server_spawnBoatLoot{};
+			class server_destroyTrash{};
+			class server_knockDownTree{};
+			class server_mineRocks{};
+			class server_lootAnimal{};
 		};
-		class epoch_player {
-			class fnc_savePlayer {};
-			class server_savePlayer {};
-			class server_loadPlayer {};
-			class server_checkPlayer {};
-			// class server_respawnPlayer {};
-			class server_onPlayerDisconnect {};
-			class server_deadPlayer {};
-			class server_revivePlayer {};
-			class server_storeCrypto {};
-			class server_equippedItem {};
-			class server_unpackBackpack {};
+		class epoch_player
+		{
+			class fnc_savePlayer{};
+			class server_savePlayer{};
+			class server_loadPlayer{};
+			class server_checkPlayer{};
+			class server_onPlayerDisconnect{};
+			class server_deadPlayer{};
+			class server_revivePlayer{};
+			class server_storeCrypto{};
+			class server_equippedItem{};
+			class server_unpackBackpack{};
+			class server_deadPlayerDetonate{};
+			class server_playerSetVariable{};
 		};
-		class epoch_traders {
-			class server_loadTraders {};
-			class server_spawnTraders {};
+		class epoch_traders
+		{
+			class server_loadTraders{};
+			class server_spawnTraders{};
 		};
-		class epoch_trading {
-			class server_makeTrade {};
-			class server_tradeRequest {};
-			class server_makeNPCTrade {};
-			class server_takeCrypto {};
+		class epoch_trading
+		{
+			class server_makeTrade{};
+			class server_tradeRequest{};
+			class server_makeNPCTrade{};
+			class server_takeCrypto{};
 		};
-		class epoch_vehicle {
-			class server_save_vehicles {};
-			class server_save_vehicle {};
-			class server_save_killedVehicle {};
-			class server_save_killedStorage {};
-			class server_save_killedBuilding {};
-			class load_vehicles {};
-			class load_storage {};
-			class server_save_storage {};
-			class spawn_vehicles {};
-			class server_lockVehicle {};
-			class server_fillVehicle {};
-			class server_repairVehicle {};
-			class server_lockStorage {};
-			class server_packStorage {};
-			class server_packJack {};
-			class spawn_vehicle {};
+		class epoch_vehicle
+		{
+			class server_save_vehicles{};
+			class server_save_vehicle{};
+			class server_save_killedVehicle{};
+			class server_save_killedStorage{};
+			class server_save_killedBuilding{};
+			class load_vehicles{};
+			class load_storage{};
+			class server_save_storage{};
+			class spawn_vehicles{};
+			class server_lockVehicle{};
+			class server_fillVehicle{};
+			class server_repairVehicle{};
+			class server_lockStorage{};
+			class server_packStorage{};
+			class server_packJack{};
+			class spawn_vehicle{};
 		};
-		class epoch_server {
-			class weightedArray {};
-			class precisionPos {};
-			class serverLootObject {};
-			class server_vehicleInit {};
-			class server_storageInit {};
-			class server_buildingInit {};
-			class server_traderKilled {};
-			class localCleanup {};
-			class server_createTeleport {};
-			class server_teleportPlayer {};
-			class returnConfig {};
-			class serverCommand {};
+		class epoch_server
+		{
+			class weightedArray{};
+			class precisionPos{};
+			class serverLootObject{};
+			class server_vehicleInit{};
+			class server_storageInit{};
+			class server_buildingInit{};
+			class server_traderKilled{};
+			class localCleanup{};
+			class server_createTeleport{};
+			class server_teleportPlayer{};
+			class returnConfig{};
+			class serverCommand{};
 		};
-		class epoch_missions {
-			class Server_createObject {};
-			class server_airDropCrate {};
-			class server_fillContainer {};
-			class Server_createAirDrop {};
+		class epoch_missions
+		{
+			class Server_createObject{};
+			class server_airDropCrate{};
+			class server_fillContainer{};
+			class Server_createAirDrop{};
 		};
-		class epoch_antagonists {
-			class server_triggerEvent {};
-			class server_handle_say3D {};
-			class server_handle_switchMove {};
-			class server_handle_sapperObjs {};
+		class epoch_antagonists
+		{
+			class server_triggerEvent{};
+			class server_handle_say3D{};
+			class server_handle_switchMove{};
+			class server_handle_sapperObjs{};
+			class server_triggerAntagonist{};
 		};
 	};
 };
@@ -141,3 +158,9 @@ class CfgServerVersion
 	config = "0.3.8.0";
 	hive = "0.5.1.7";
 };
+class cfgMods
+{
+	author = "";
+	timepacked = "1458312578";
+};
+//};


### PR DESCRIPTION
ADDED: Player option to Morph into a random antagonist (from deathMorphClass) after death.

Player conscience transfers to the antagonist and can watch from their eyes. the antagonist conscience is too strong currently to allow full control..

Option to Groan or manually detonate a sapper. Player Revival still available. Cultist currently available during the day, ToDo: night only ?.

ADDED: Player option to detonate body after death. Sacrifice yourself by generating a runaway thermal cascade using the nano bots within your body. Nothing left to revive.

Player Killer, if available, is set as the target and is required for the victim to see the new menu. A suicide / antagonist death will show standard respawn button and countdown.

Checks are done, as per normal antagonist spawn, so as not to spawn, or detonate, when too close to a base or protected area / trader.

Should help make PVP environments more interesting, giving the new spawn a better chance (or at least some entertainment after being shot) and generate more antagonists.

Only one retaliatory (morphed) antagonist is allowed per killer, additional kills will result in victims 'sharing' the spawned antagonist so long as it is still alive.

Those additional shared antagonist spawn / morph requests will stack up though, causing a high scoring PVPer to generate more antagonists in the long run.

Trolling with vehicles or spawn camping for cheap returns has become a more risky business.

ADDED: Server function to allow remote exec of setVariable on client - Allows client to ask another client to set a local variable, via the server. Server can run same function.

ADDED: Functions to support the new respawn options:

Sapper groan or detonate can be triggered by setting a variable on the target or sapper.

Server can be asked by a client / server to trigger an antagonist on another client. Antagonist is then run on target PC, independent from caller of function.

DEV: When calling antagonist, an option to mark the target with a setvariable is available. Beware, as this will lead to the caller being attached to the antagonist, could be interesting, not tested beyond using it for the new features.

UPDATED: Epoch Unit Spawn code. Now can be called specifying the target of the antagonist. Antagonist will run on target client PC.

UPDATED - Sapper defaults tweaked to make them more responsive.

ADDED: Additional Antagonist Options in CfgEpochClient:

Player Morph
 deathMorphClass - Specify an array of antagonists to randomly spawn from.

Sapper
 reflexSpeed - Set the loop pause. Defaults have been lowered to make sapper more responsive.
 nestChance - A percentage chance, at each sapper spwan, that he will create a nest.
 hideLevel - (Fear Emotion) Set level at which sapper will go into hiding based on fear of armed players, being shot near etc.
 chargeLevel - (Anger Emotion) Set level at which sapper will trigger 'charge the player' mode.

UAV Support Troops
 unitTypes - an array of soldier classes to randomly choose from. Custom weapons to-do, use soldiers with default weapon loadout or handle weapons with custom script.
 maxUnitNum - Maximum number of units to spawn per UAV.
 minAISkill - Minimum value for any AI skill.
 maxAimingAccuracy -> maxGeneral - Set the maximum value for each available AI skill. A random number between minAISkill and the value for each will be set as that skill.

CREDIT: A big thanks to my chief tester, Isaac.
