### PR TITLE
Update EPOCH_worldObjectType.sqf

### DIFF
--- a/Sources/epoch_code/compile/functions/EPOCH_worldObjectType.sqf
+++ b/Sources/epoch_code/compile/functions/EPOCH_worldObjectType.sqf
@@ -22,6 +22,7 @@
 	Returns:
 	BOOL or ARRAY of BOOLs
 */
+private ["_str","_return","_config","_findStart","_start","_end","_p3dName","_finalConfig","_checkType"];
 params ["_str","_checkType"];
 _return = false;
 _config = 'CfgEpochClient' call EPOCH_returnConfig;


### PR DESCRIPTION
Added private Variables, so external scripts calling this script can use "_return" as variable without problems

example EPOCH_lootTrash.sqf:
_return = false;
_getWorldTypes = [str(_x), _inputWorldTypes] call EPOCH_worldObjectType;
_return  <--- Is an array!!!
