### PR TITLE
fix CBA_A3 keybinding incompatibility

### DIFF
--- a/Sources/epoch_code/compile/interface_event_handlers/EPOCH_KeyDown.sqf
+++ b/Sources/epoch_code/compile/interface_event_handlers/EPOCH_KeyDown.sqf
@@ -266,4 +266,5 @@ if (_dikCode in (actionKeys "NightVision")) then {
 	};
 };
 
-_handled
+// only return anything if _handled actually is true
+if (_handled isEqualTo true) then {true};

--- a/Sources/epoch_code/compile/interface_event_handlers/EPOCH_KeyUp.sqf
+++ b/Sources/epoch_code/compile/interface_event_handlers/EPOCH_KeyUp.sqf
@@ -36,4 +36,6 @@ if (_dikCode == EPOCH_keysAction) then {
 if (_dikCode in(actionKeys "Gear")) then {
 	EPOCH_gearKeyPressed = false;
 };
-_handled
+
+// only return anything if _handled actually is true
+if (_handled isEqualTo true) then {true};


### PR DESCRIPTION
note: this is just one step into making Epoch more CBA compatible. there might be more problems.
especially the epoch AH will most likely still make problems when replacing the EH.
