### PR TITLE
Fix for "add wall" to Wooden Tower

### DIFF
--- a/Sources/epoch_code/compile/building/EPOCH_changeWallState.sqf
+++ b/Sources/epoch_code/compile/building/EPOCH_changeWallState.sqf
@@ -67,7 +67,6 @@ if !(isNull _object) then{
 				_recipeItem = _x;
 				_recipeQty = 1;
 				if (_x isEqualType[]) then{
-					_x params ["_recipeItem","_recipeQty"];
 					_recipeItem = _x select 0;
 					_recipeQty = _x select 1;
 				};


### PR DESCRIPTION
Add Wall on Wooden Tower was not working since 0.4. 
_x params ["_recipeItem","_recipeQty"];	 seem not work here and the paramterer was twice loaded.
This fix is already tested and works.