### PR TITLE
Skip saving already killed Vehicles

### DIFF
--- a/Sources/epoch_server/compile/epoch_vehicle/EPOCH_server_save_vehicle.sqf
+++ b/Sources/epoch_server/compile/epoch_vehicle/EPOCH_server_save_vehicle.sqf
@@ -17,7 +17,7 @@ params [["_vehicle",objNull]];
 
 if (!isNull _vehicle) then {
 
-	// if (!alive _vehicle) exitWith {diag_log format["DEBUG DEAD VEHICLE SKIPPED SAVE: %1 %2", _vehicle]};
+	if (!alive _vehicle) exitWith {diag_log format["DEBUG DEAD VEHICLE SKIPPED SAVE: %1 %2", _vehicle]};
 	_vehSlot = _vehicle getVariable["VEHICLE_SLOT", "ABORT"];
 	if (_vehSlot != "ABORT") then {
 


### PR DESCRIPTION
Server was deleting the Vehicle from DB and after hit is triggered, saved it again into DB with damage 1