### PR TITLE
Prevent Groupmenu from instantly closing

### DIFF
--- a/Sources/epoch_code/gui/scripts/group/EPOCH_Group_onLoad.sqf
+++ b/Sources/epoch_code/gui/scripts/group/EPOCH_Group_onLoad.sqf
@@ -18,7 +18,7 @@ private ["_BtnInvite","_GroupMemberList","_InvitePlayerCombo","_currentMaxMember
 disableSerialization;
 _display = findDisplay -1300;
 _BtnInvite = _display displayCtrl 30;
-
+_eh = _display displayaddeventhandler ['KeyUp',{true}];
 _GroupMemberList = _display displayCtrl 40;
 _InvitePlayerCombo = _display displayCtrl 41;
 


### PR DESCRIPTION
Prevent Groupmenu from instantly closing after release Space Bar.
Not Sure, if this will work with Epoch AH and / or if BE-Filters are required.