### PR TITLE
Faster feedback from Targets

### DIFF
--- a/Sources/epoch_code/compile/interface_event_handlers/EPOCH_KeyDown.sqf
+++ b/Sources/epoch_code/compile/interface_event_handlers/EPOCH_KeyDown.sqf
@@ -83,6 +83,7 @@ if (_dikCode == EPOCH_keysDebugMon) then {
 //Action Menu
 if (_dikCode == EPOCH_keysAction) then {
 	//_handled = true;
+	{player reveal _x;} foreach (player nearObjects 50);
 	if !(EPOCH_keysActionPressed) then {
 		EPOCH_keysActionPressed = true;
 		if (cursorTarget isKindOf "AllVehicles") then {


### PR DESCRIPTION
reaveal player to all near objects on Epoch-ActionKey pressed.
Whithout this, upgraded Buildings need up to 10 seconds to get in Target.