### PR TITLE
Set damage to value, not to 0

### DIFF
--- a/Sources/epoch_server/compile/epoch_vehicle/EPOCH_server_repairVehicle.sqf
+++ b/Sources/epoch_server/compile/epoch_vehicle/EPOCH_server_repairVehicle.sqf
@@ -18,7 +18,7 @@ if !([_player,  _token] call EPOCH_server_getPToken) exitWith{};
 if (_player distance _vehicle > 20) exitWith{};
 
 if ((_value select 0) isEqualTo "ALL") then {
-	_vehicle setDamage 0;
+	_vehicle setDamage (_value select 1);
 } else {
 	if (local _vehicle) then {
 		_vehicle setHitIndex _value;


### PR DESCRIPTION
All Scripts are using as params ['ALL',0].
With this change it is possible to set the damage to a value (0 for all actual scripts).