### PR TITLE
Force "TakeCrypto" menu on dead Player

### DIFF
--- a/Sources/epoch_config/Configs/CfgActionMenu/CfgActionMenu_target.hpp
+++ b/Sources/epoch_config/Configs/CfgActionMenu/CfgActionMenu_target.hpp
@@ -79,7 +79,7 @@ class tra_shop
 
 class player_takeCrypto
 {
-	condition = "(dyna_cursorTarget getVariable [""Crypto"",0]) > 0";
+	condition = "dyna_isDeadPlayer || (dyna_cursorTarget getVariable [""Crypto"",0]) > 0";
 	action = "dyna_cursorTarget call EPOCH_takeCrypto;";
 	icon = "x\addons\a3_epoch_code\Data\UI\buttons\krypto.paa";
 	tooltip = "Take Krypto";


### PR DESCRIPTION
Dead Player sometimes comes hard in target and Players are trying and trying to get "Take Krypto".
So it's better to make it everytime available on Dead Player.