### PR TITLE
Make SpawnPoint on Player Pos + Bugfix

### DIFF
--- a/Sources/epoch_server/compile/epoch_player/EPOCH_server_loadPlayer.sqf
+++ b/Sources/epoch_server/compile/epoch_player/EPOCH_server_loadPlayer.sqf
@@ -120,7 +120,7 @@ if (!isNull _player) then {
             _location = getMarkerPos "respawn_west";
             _location set[2, 0];
             if (_newLocation isEqualType [] && {(count _newLocation) == 3}) then {
-                _jammers = nearestObjects[_newLocation, ["PlotPole_EPOCH"], 1];
+                _jammers = nearestObjects[_newLocation, ["PlotPole_EPOCH"], 6];
                 if !(_jammers isEqualTo[]) then {
                     // get nearby object
                     _jammer = _jammers param [0,objNull];

--- a/Sources/epoch_server/compile/epoch_player/EPOCH_server_loadPlayer.sqf
+++ b/Sources/epoch_server/compile/epoch_player/EPOCH_server_loadPlayer.sqf
@@ -120,7 +120,7 @@ if (!isNull _player) then {
             _location = getMarkerPos "respawn_west";
             _location set[2, 0];
             if (_newLocation isEqualType [] && {(count _newLocation) == 3}) then {
-                _jammers = nearestObjects[_newLocation, ["PlotPole_EPOCH"], 6];
+                _jammers = nearestObjects[_newLocation, ["PlotPole_EPOCH"], 6 ];
                 if !(_jammers isEqualTo[]) then {
                     // get nearby object
                     _jammer = _jammers param [0,objNull];

--- a/Sources/epoch_server/compile/epoch_player/EPOCH_server_loadPlayer.sqf
+++ b/Sources/epoch_server/compile/epoch_player/EPOCH_server_loadPlayer.sqf
@@ -120,7 +120,7 @@ if (!isNull _player) then {
             _location = getMarkerPos "respawn_west";
             _location set[2, 0];
             if (_newLocation isEqualType [] && {(count _newLocation) == 3}) then {
-                _jammers = nearestObjects[_newLocation, ["PlotPole_EPOCH"], 6 ];
+                _jammers = nearestObjects[_newLocation, ["PlotPole_EPOCH"], 6];
                 if !(_jammers isEqualTo[]) then {
                     // get nearby object
                     _jammer = _jammers param [0,objNull];

--- a/Sources/epoch_server/compile/epoch_player/EPOCH_server_makeSP.sqf
+++ b/Sources/epoch_server/compile/epoch_player/EPOCH_server_makeSP.sqf
@@ -25,10 +25,13 @@ if (alive _jammer) then {
         _server_vars = _player getVariable["SERVER_VARS", []];
         _currentPos = _server_vars param [0,[]];
         // invalidate previous position
+		if (!(_currentPos isequaltype [])) then {
+			_currentPos = [];
+		};
         if (!(_currentPos isEqualTo []) && {_jammer distance _currentPos > 20}) then { _currentPos = [] };
         if (_currentPos isEqualTo []) then {
             // set position of spawnpoint to players SERVER_VARS
-            _server_vars set [0, getposATL _jammer]; // 0 = RESPAWN POS
+            _server_vars set [0, getposATL _player]; // 0 = RESPAWN POS
             _player setVariable ["SERVER_VARS", _server_vars];
             ["Spawnpoint set", 5] remoteExec ['Epoch_message',_player];
         }


### PR DESCRIPTION
More accurate to define for Players (bugging through a wall and falling down or hanging stuck in a corner)

In EPOCH 0.4, ServerVars was set to [""] in case of wrong _varscount.
If you have it on your character, you are not able to set SpawnPoint.
SO I added a check, if spawnlocation isequaltype []