### PR TITLE
Prevent Group Menus from Closing on space release

### DIFF
--- a/Sources/epoch_code/compile/interface_event_handlers/EPOCH_KeyUp.sqf
+++ b/Sources/epoch_code/compile/interface_event_handlers/EPOCH_KeyUp.sqf
@@ -31,6 +31,10 @@ private ["_handled"];
 params ["_display","_dikCode","_shift","_ctrl","_alt"];
 _handled = false;
 
+if (!isnull (finddisplay -1200) || !isnull (finddisplay -1300) || !isnull (finddisplay -1400)) then {
+	_handled = true;
+};
+
 _this call Epoch_custom_EH_KeyUp;
 if (_handled) exitWith{ true };
 


### PR DESCRIPTION
Not tested, but in other way already on my Server:
disableserialization;
waituntil {!isnull (finddisplay -1200) || !isnull (finddisplay -1300) || !isnull (finddisplay -1400)};
_display = displaynull;
{
	if (!isnull (finddisplay _x)) exitwith {
		_display = finddisplay _x;
	};
} foreach [-1200,-1300,-1400];
_eh = _display displayaddeventhandler ['KeyUp',{true}];