### PR TITLE
Fix for create / leave Group

### DIFF
--- a/Sources/epoch_code/gui/scripts/group/EPOCH_iGroup_refresh.sqf
+++ b/Sources/epoch_code/gui/scripts/group/EPOCH_iGroup_refresh.sqf
@@ -15,7 +15,7 @@
 //[[[cog import generate_private_arrays ]]]
 private ["_index"];
 //[[[end]]]
-if !(Epoch_invited_GroupUIDs isEqualTo Epoch_invited_GroupUIDsPrev) then {
+if !(Epoch_invited_GroupUIDs isEqualTo []) then {
 	Epoch_invited_GroupUIDsPrev = Epoch_invited_GroupUIDs;
 	lbClear 1500;
 	{

--- a/Sources/epoch_server/compile/epoch_group/EPOCH_server_updatePlayerGroup.sqf
+++ b/Sources/epoch_server/compile/epoch_group/EPOCH_server_updatePlayerGroup.sqf
@@ -12,21 +12,18 @@
     Github:
     https://github.com/EpochModTeam/Epoch/tree/release/Sources/epoch_server/compile/epoch_group/EPOCH_server_updatePlayerGroup.sqf
 */
-private ["_groupID","_selectedPlayerUID","_addOrRemove","_modOrMember","_modOrMemberRevert","_response","_contentArray","_modArray","_memberArray","_selectedPlayerName","_group","_removePlayerArray","_modOrMemberArray","_found"];
+private ["_modOrMember","_modOrMemberRevert","_response","_contentArray","_modArray","_memberArray","_selectedPlayerName","_group","_removePlayerArray","_modOrMemberArray","_found"];
+params [["_groupID",""],["_selectedPlayerUID",""],["_addOrRemove",false],["_modOrMemberVar",true],["_player",objnull],["_token",""]];
 
-if !([_this select 4, _this select 5] call EPOCH_server_getPToken) exitWith {};
+if !([_player, _token] call EPOCH_server_getPToken) exitWith {};
 
-_groupID = _this select 0;
 if (_groupID == "") exitWith{ diag_log format["Epoch: GROUP: No Group Selected %1", _this]; };
 
 diag_log format["Epoch: GROUP: Update %1", _this];
 
-_selectedPlayerUID = _this select 1;
-_addOrRemove = _this select 2; //add = true
-_modOrMember = if (_this select 3) then [{3},{4}];
-_modOrMemberRevert = if (_this select 3) then [{4},{3}];
+_modOrMember = if (_modOrMemberVar) then [{3},{4}];
+_modOrMemberRevert = if (_modOrMemberVar) then [{4},{3}];
 
-// [_groupName, _leaderName, _groupSize, _modArray, _memberArray]
 _response = ["Group", _groupID] call EPOCH_fnc_server_hiveGETRANGE;
 if ((_response select 0) == 1 && (_response select 1) isEqualType []) then {
 	_contentArray = _response select 1;
@@ -39,7 +36,6 @@ if ((_response select 0) == 1 && (_response select 1) isEqualType []) then {
 		{
 			_selectedPlayerName = if (alive _x) then {name _x};
 			if ((_x getVariable ["GROUP",""]) != _groupID) then {
-				_x setVariable ["GROUP", _groupID];
 				_group = grpNull;
 				{
 					if ((_x getVariable["GROUP",""]) == _groupID) exitWith {
@@ -50,6 +46,8 @@ if ((_response select 0) == 1 && (_response select 1) isEqualType []) then {
 				if (isNull _group) then {
 					_group = createGroup [west, true];
 				};
+				_x setVariable ["GROUP", _groupID];
+				[["groupUidUpdate", _groupID], _x] call EPOCH_sendRemoteExecClient;
 				[_x] joinSilent _group;
 			};
 		} forEach (_allPlayers select {getPlayerUID _x == _selectedPlayerUID});
@@ -88,7 +86,6 @@ if ((_response select 0) == 1 && (_response select 1) isEqualType []) then {
 			[_x] joinSilent (createGroup [west, true]);
 			[["resetGroup", true], _x] call EPOCH_sendRemoteExecClient;
 		} forEach (_allPlayers select {getPlayerUID _x == _selectedPlayerUID});
-
 		{
 			if (_x select 0 == _selectedPlayerUID) exitWith {
 				_memberArray deleteAt _forEachIndex;


### PR DESCRIPTION
- Server was looking for Players with Groupuid after the UID was already set on the new member. So the Player was sometimes found as first and has joined his own Group
- [["groupUidUpdate", _groupID], _x] call EPOCH_sendRemoteExecClient; was missing, so the Player had to relog to get the Groupuid variable -> Leaving group was also only possible after Relog
- added usage of params []

- Once closed the Invites Screen, no more invites from the same Group are possible until relog.
- Not sure, for what "Epoch_invited_GroupUIDsPrev" should be needed. Noticed no disadvantages by not compare it here