### PR TITLE
Force Save Player after Spawnpoint set

### DIFF
--- a/Sources/epoch_server/compile/epoch_player/EPOCH_server_makeSP.sqf
+++ b/Sources/epoch_server/compile/epoch_player/EPOCH_server_makeSP.sqf
@@ -36,6 +36,7 @@ if (alive _jammer) then {
             // set position of spawnpoint to players SERVER_VARS
             _server_vars set [0, getposATL _player]; // 0 = RESPAWN POS
             _player setVariable ["SERVER_VARS", _server_vars];
+	    [_player, _player getVariable["VARS", []]] call EPOCH_server_savePlayer;
             ["Spawnpoint set", 5] remoteExec ['Epoch_message',_player];
         }
         else
@@ -43,6 +44,7 @@ if (alive _jammer) then {
             // remove position of spawnpoint from players SERVER_VARS
             _server_vars set [0, []]; // 0 = RESPAWN POS
             _player setVariable ["SERVER_VARS", _server_vars];
+	    [_player, _player getVariable["VARS", []]] call EPOCH_server_savePlayer;
             ["Spawnpoint removed", 5] remoteExec ['Epoch_message',_player];
         };
     }


### PR DESCRIPTION
If not force save, sometimes the Spawnpoint is not saved after death (if to close after set)