### PR TITLE
Prevent "SmokeShell" from FavBar

### DIFF
--- a/Sources/epoch_code/gui/scripts/favBar/epoch_favBar_draw.sqf
+++ b/Sources/epoch_code/gui/scripts/favBar/epoch_favBar_draw.sqf
@@ -61,12 +61,11 @@ switch _action do {
 		if (rmx_var_favBar_Item in rmx_var_favBar_current) exitWith {"Item already exists in favorites!" call epoch_message; false}; //if duplicate
 		
 		_type = (rmx_var_favBar_Item call BIS_fnc_itemType) select 1;
-		_isBanned = _type in ["BombLauncher", "Cannon", "GrenadeLauncher", "Launcher", "MissileLauncher", "RocketLauncher", "Magazine", "Mortar", "Shotgun","Rocket","Grenade"];
+		_isBanned = _type in ["BombLauncher", "Cannon", "GrenadeLauncher", "Launcher", "MissileLauncher", "RocketLauncher", "Magazine", "Mortar", "Shotgun","Rocket","Grenade","SmokeShell"];
 		_isAmmo = _type == "Bullet" && !(rmx_var_favBar_Item in ["EnergyPack","EnergyPackLg"]); 
-		_isChemlight = rmx_var_favBar_Item in ["Chemlight_green","Chemlight_red","Chemlight_yellow","Chemlight_blue"];
 		
 		//if (_type in ["AccessoryMuzzle","AccessoryPointer","AccessorySights","AccessoryBipod"]) exitWith {"Attachments are not supported at the moment!" call epoch_message; false};
-		if (_isBanned || _isAmmo || _isChemlight) exitWith {"Item cannot be added to favorites!" call epoch_message; false}; //Don't allow certain types
+		if (_isBanned || _isAmmo) exitWith {"Item cannot be added to favorites!" call epoch_message; false}; //Don't allow certain types
 		
 		_itemIsWeapon = [rmx_var_favBar_Item, "CfgWeapons"] call EPOCH_fnc_isAny;
 		_itemHasInteraction = str(missionConfigFile >> "CfgItemInteractions" >> rmx_var_favBar_Item) != "";


### PR DESCRIPTION
- Prevent "SmokeShell" from FavBar, because throwing is not working
- Check for Chemliight no longer needed, because it also count as "SmokeShell"