### PR TITLE
Moved Vehicle Upgrade to DynaMenu

### DIFF
--- a/Sources/epoch_code/compile/inventory/EPOCH_itemInteractClick.sqf
+++ b/Sources/epoch_code/compile/inventory/EPOCH_itemInteractClick.sqf
@@ -64,6 +64,7 @@ else {
 	EPOCH_CraftingItem = "";
 };
 
+/* Moved to DynaMenu
 _config = 'CfgVehicleUpgrades' call EPOCH_returnConfig;
 if (isClass (_config >> _data)) then {
     {
@@ -80,6 +81,7 @@ if (isClass (_config >> _data)) then {
         };
     } foreach (nearestobjects [player,["Landvehicle","SHIP","AIR","TANK"],10]);
 };
+*/
 
 if !(_button_texts isEqualTo []) then {
     _display = ctrlParent (_this select 0);

--- a/Sources/epoch_code/compile/vehicles/EPOCH_client_upgradeVehicle.sqf
+++ b/Sources/epoch_code/compile/vehicles/EPOCH_client_upgradeVehicle.sqf
@@ -1,28 +1,32 @@
-if (isnil 'EPOCH_UpgradeVehicle') exitwith {
-	["Upgrade failed - Error",5] call Epoch_message;
-};
+/*
+	Author: He-Man / DirtySanchez
 
-EPOCH_UpgradeVehicle params ["_data",["_veh",objnull]]; 
-EPOCH_UpgradeVehicle = nil;
+    Contributors: 
 
+	Description:
+	Upgrade Vehicle
+
+    Licence:
+    Arma Public License Share Alike (APL-SA) - https://www.bistudio.com/community/licenses/arma-public-license-share-alike
+
+    Github:
+    https://github.com/EpochModTeam/Epoch/tree/release/Sources/epoch_code/compile/vehicles/EPOCH_client_upgradeVehicle.sqf
+*/
+
+private ["_vehType","_config","_reqMaterials","_crypto","_hasall","_missing","_has","_msg"];
+params [["_veh",objnull],["_classUpgrade",""],["_displayname",""],["_mattxt",""]];
+
+Ignatz_VehicleUpgradeArray = [];
 if (isnull _veh) exitwith {
 	["Upgrade failed - Vehicle not found",5] call Epoch_message;
 };
-if (player distance _veh > 12) exitwith {
-	["Upgrade failed - Vehicle to far away",5] call Epoch_message;
-};
-if !(local _veh) exitwith {
-	["Upgrade failed - Go in as Driver first",5] call Epoch_message;
-};
-if !(crew _veh isequalto []) exitwith {
-	["Upgrade failed - All passengers must leave the Vehicle",5] call Epoch_message;
-};
 
 _vehType = typeOf _veh;
-
 _config = 'CfgVehicleUpgrades' call EPOCH_returnConfig;
-_classUpgrade = gettext (_config >> _data >> _vehType >> "upgradeToVehicle");
-_reqMaterials = getArray (_config >> _data >> _vehType >> "ReqMaterials");
+if !(isclass (_config >> _vehType)) exitwith {
+	["Vehicle not upgradeable",5] call Epoch_message;
+};
+_reqMaterials = getArray (_config >> _vehType >> _classUpgrade >> "ReqMaterials");
 
 _crypto = 0;
 if(_reqMaterials isEqualTo [])exitWith{
@@ -51,6 +55,19 @@ if (!_hasall) exitwith {
 	} foreach _missing;
 	[_msg,5] call Epoch_message;
 };
+if !(local _veh) exitwith {
+	["Upgrade failed - Go in as Driver first",5] call Epoch_message;
+};
+if !(crew _veh isequalto []) exitwith {
+	["Upgrade failed - All passengers must leave the Vehicle",5] call Epoch_message;
+};
+if (player distance _veh > 15) exitwith {
+	["Upgrade failed - Vehicle to far away",5] call Epoch_message;
+};
+if (player distance _veh < 4.5) exitwith {
+	["Upgrade failed - Take a bit distance and try again",5] call Epoch_message;
+};
+
 {
 	_x params ["_count","_item"];
 	if (_item isequalto "Crypto") then {
@@ -62,4 +79,5 @@ if (!_hasall) exitwith {
 		};
 	};
 } forEach _reqMaterials;
+
 [[_veh,_classUpgrade,_crypto],player,Epoch_personalToken] remoteExec ["EPOCH_server_upgrade_vehicle",2];

--- a/Sources/epoch_code/compile/vehicles/EPOCH_client_upgradeVehicleCheck.sqf
+++ b/Sources/epoch_code/compile/vehicles/EPOCH_client_upgradeVehicleCheck.sqf
@@ -1,0 +1,51 @@
+/*
+	Author: He-Man
+
+    Contributors: DirtySanchez
+
+	Description:
+	Upgrade Vehicle Check
+
+    Licence:
+    Arma Public License Share Alike (APL-SA) - https://www.bistudio.com/community/licenses/arma-public-license-share-alike
+
+    Github:
+    https://github.com/EpochModTeam/Epoch/tree/release/Sources/epoch_code/compile/vehicles/EPOCH_client_upgradeVehicleCheck.sqf
+*/
+
+private ["_veh","_vehType","_config","_classUpgrade","_reqMaterials","_mattxt","_displayname"];
+_veh = _this;
+
+Ignatz_VehicleUpgradeArray = [];
+if (isnull _veh) exitwith {
+	["Upgrade failed - Vehicle not found",5] call Epoch_message;
+};
+if (player distance _veh > 12) exitwith {
+	["Upgrade failed - Vehicle to far away",5] call Epoch_message;
+};
+
+_vehType = typeOf _veh;
+_config = 'CfgVehicleUpgrades' call EPOCH_returnConfig;
+if !(isclass (_config >> _vehType)) exitwith {
+	["Vehicle not upgradeable",5] call Epoch_message;
+};
+_classUpgrade = getarray (_config >> _vehType >> "upgradeToVehicle");
+if (_classUpgrade isequalto []) exitwith {
+	["Vehicle not upgradeable",5] call Epoch_message;
+};
+
+{
+	_classUpgrade = _x;
+	if (_x isequaltype []) then {
+		_classUpgrade = selectrandom _x;
+	};
+	if (isclass (_config >> _vehType >> _classUpgrade)) then {
+		_reqMaterials = getArray (_config >> _vehType >> _classUpgrade >> "ReqMaterials");
+		_mattxt = "Needed:";
+		{
+			_mattxt = _mattxt + format [' %1 %2,', _x select 0, (_x select 1) call EPOCH_itemDisplayName];
+		} forEach _reqMaterials;
+		_displayname = _classUpgrade call EPOCH_itemDisplayName;
+		Ignatz_VehicleUpgradeArray pushback [_veh,_classUpgrade,_displayname,_mattxt];
+	};
+} foreach _classUpgrade;

--- a/Sources/epoch_code/gui/scripts/dynamenu/Epoch_dynamicMenu.sqf
+++ b/Sources/epoch_code/gui/scripts/dynamenu/Epoch_dynamicMenu.sqf
@@ -1,7 +1,7 @@
 /*
 	Author: Raimonds Virtoss - EpochMod.com
 
-    Contributors:
+    Contributors: He-Man
 
 	Description:
 	DESC-TBA
@@ -14,7 +14,7 @@
 */
 disableSerialization;
 //[[[cog import generate_private_arrays ]]]
-private ["_action","_arr","_buttonSettings","_c","_cfg","_checkConfigs","_config","_configs","_dName","_display","_entries","_hasTarget","_icon","_in","_selfOrTarget","_subclasses","_tTip","_tooltip","_tooltipcode","_x"];
+private ["_iconcode","_action","_arr","_buttonSettings","_c","_cfg","_checkConfigs","_config","_configs","_dName","_display","_entries","_hasTarget","_icon","_in","_selfOrTarget","_subclasses","_tTip","_tooltip","_tooltipcode","_x"];
 //[[[end]]]
 _in = [_this, 0, "",[""]] call BIS_fnc_param;
 
@@ -118,9 +118,21 @@ _checkConfigs = {
 						else {
 							_tooltip = getText(_x >> "tooltip");
 						};
+						
+						_icon = "";
+						_iconcode = getText(_x >> "iconcode");
+						if (_iconcode != "") then {
+							_icon = [] call compile _iconcode;
+						}
+						else {
+							_icon = getText(_x >> "icon");
+						};
+						if (!(_icon isequaltype "") || _icon isequalto "") then {
+							_icon = "x\addons\a3_epoch_code\Data\UI\buttons\player_inspect.paa";
+						};
 
 						_buttonSettings pushBack [
-							getText(_x >> "icon"),
+							_icon,
 							_tooltip,
 							_action
 						];

--- a/Sources/epoch_config/Configs/CfgActionMenu/CfgActionMenu_core.hpp
+++ b/Sources/epoch_config/Configs/CfgActionMenu/CfgActionMenu_core.hpp
@@ -21,7 +21,7 @@ class CfgActionMenu
 		dyna_cursorTargetType = "typeOf ([10] call EPOCH_fnc_cursorTarget)";
 		dyna_inVehicle = "vehicle player != player";
 		dyna_itemsPlayer = "items player";
-		dyna_sizeOf = "((sizeOf dyna_cursorTargetType/2) max 5) min 30";
+		dyna_sizeOf = "((sizeOf dyna_cursorTargetType/2) max 6) min 30";
 		dyna_distance = "(player distance dyna_cursorTarget) <= dyna_sizeOf";
 
 		dyna_buildMode = "([10] call EPOCH_fnc_cursorTarget) call EPOCH_checkBuild;";

--- a/Sources/epoch_config/Configs/CfgActionMenu/CfgActionMenu_target.hpp
+++ b/Sources/epoch_config/Configs/CfgActionMenu/CfgActionMenu_target.hpp
@@ -461,4 +461,46 @@ class VehMaintanance
 			tooltip = "Remove 4th Right Wheel";
 		};
 	};
+	class UpgradeVehicle
+	{
+		condition = "dyna_isVehicle";
+		action = "dyna_cursorTarget call EPOCH_client_upgradeVehicleCheck;";
+		icon = "x\addons\a3_epoch_code\Data\UI\buttons\build_upgrade.paa";
+		tooltip = "Upgrade Vehicle";
+		class Upgrade0
+		{
+			condition = "(count Ignatz_VehicleUpgradeArray) > 0";
+			action = "(Ignatz_VehicleUpgradeArray select 0) call EPOCH_client_upgradeVehicle";
+			iconcode = "gettext (configfile >> 'CfgVehicles' >> (Ignatz_VehicleUpgradeArray select 0 select 1) >> 'picture')";
+			tooltipcode = "format ['Upgrade to %1 - %2',(Ignatz_VehicleUpgradeArray select 0 select 2),(Ignatz_VehicleUpgradeArray select 0 select 3)]";
+		};
+		class Upgrade1
+		{
+			condition = "(count Ignatz_VehicleUpgradeArray) > 1";
+			action = "(Ignatz_VehicleUpgradeArray select 1) call EPOCH_client_upgradeVehicle";
+			iconcode = "gettext (configfile >> 'CfgVehicles' >> (Ignatz_VehicleUpgradeArray select 1 select 1) >> 'picture')";
+			tooltipcode = "format ['Upgrade to %1 - %2',(Ignatz_VehicleUpgradeArray select 1 select 2),(Ignatz_VehicleUpgradeArray select 1 select 3)]";
+		};
+		class Upgrade2
+		{
+			condition = "(count Ignatz_VehicleUpgradeArray) > 2";
+			action = "(Ignatz_VehicleUpgradeArray select 2) call EPOCH_client_upgradeVehicle";
+			iconcode = "gettext (configfile >> 'CfgVehicles' >> (Ignatz_VehicleUpgradeArray select 2 select 1) >> 'picture')";
+			tooltipcode = "format ['Upgrade to %1 - %2',(Ignatz_VehicleUpgradeArray select 2 select 2),(Ignatz_VehicleUpgradeArray select 2 select 3)]";
+		};
+		class Upgrade3
+		{
+			condition = "(count Ignatz_VehicleUpgradeArray) > 3";
+			action = "(Ignatz_VehicleUpgradeArray select 3) call EPOCH_client_upgradeVehicle";
+			iconcode = "gettext (configfile >> 'CfgVehicles' >> (Ignatz_VehicleUpgradeArray select 3 select 1) >> 'picture')";
+			tooltipcode = "format ['Upgrade to %1 - %2',(Ignatz_VehicleUpgradeArray select 3 select 2),(Ignatz_VehicleUpgradeArray select 3 select 3)]";
+		};
+		class Upgrade4
+		{
+			condition = "(count Ignatz_VehicleUpgradeArray) > 4";
+			action = "(Ignatz_VehicleUpgradeArray select 4) call EPOCH_client_upgradeVehicle";
+			iconcode = "gettext (configfile >> 'CfgVehicles' >> (Ignatz_VehicleUpgradeArray select 4 select 1) >> 'picture')";
+			tooltipcode = "format ['Upgrade to %1 - %2',(Ignatz_VehicleUpgradeArray select 4 select 2),(Ignatz_VehicleUpgradeArray select 4 select 3)]";
+		};
+	};
 };

--- a/Sources/epoch_config/Configs/CfgClientFunctions.hpp
+++ b/Sources/epoch_config/Configs/CfgClientFunctions.hpp
@@ -154,6 +154,7 @@ class CfgClientFunctions
             class client_fillVehicle {};
             class client_gearVehicle {};
 			class client_upgradeVehicle {};
+			class client_upgradeVehicleCheck {};
 			class client_VehicleMaintananceCheck {};
 			class client_VehicleMaintananceDo {};
         };

--- a/Sources/epoch_config/Configs/CfgVehicleUpgrades.hpp
+++ b/Sources/epoch_config/Configs/CfgVehicleUpgrades.hpp
@@ -1,314 +1,114 @@
 /*
     @author = "Aaron Clark - https://EpochMod.com";
-    @contributors[] = {"DirtySanchez"};
+    @contributors[] = {"DirtySanchez","He-Man"};
     @description = "Vehicle Upgrade configs";
     @licence = "Arma Public License Share Alike (APL-SA) - https://www.bistudio.com/community/licenses/arma-public-license-share-alike";
     @github = "https://github.com/EpochModTeam/Epoch/tree/release/Sources/epoch_config/Configs/CfgItemInteractions.hpp";
 */
 class CfgVehicleUpgrades
 {
-	class ItemVehDoc1
+	class C_Hatchback_01_EPOCH
 	{
-		class C_Hatchback_01_EPOCH
-		{
-			ReqMaterials[] = {{1,"ItemVehDoc1"},{1,"ItemCables"},{1,"CircuitParts"},{2,"VehicleRepairLg"}};
-			upgradeToVehicle = "C_Hatchback_01_EPOCH1";
-		};
-		class C_Hatchback_02_EPOCH: C_Hatchback_01_EPOCH	{	upgradeToVehicle = "C_Hatchback_02_EPOCH1";	};
-		class C_Offroad_01_EPOCH: C_Hatchback_01_EPOCH		{	upgradeToVehicle = "C_Offroad_01_EPOCH1";	};
-		class C_SUV_01_EPOCH: C_Hatchback_01_EPOCH			{	upgradeToVehicle = "C_SUV_01_EPOCH1";		};
-		class B_MRAP_01_EPOCH: C_Hatchback_01_EPOCH			{	upgradeToVehicle = "B_MRAP_01_EPOCH1";		};
-		class O_MRAP_02_EPOCH: C_Hatchback_01_EPOCH			{	upgradeToVehicle = "O_MRAP_02_EPOCH1";		};
-		class I_MRAP_03_EPOCH: C_Hatchback_01_EPOCH			{	upgradeToVehicle = "I_MRAP_03_EPOCH1";		};
-	};
-	class KitVehicleUpgradeI_100_EPOCH
-	{
-		class C_Hatchback_01_EPOCH
-		{
-			ReqMaterials[] = {{1,"KitVehicleUpgradeI_100_EPOCH"}};
-			upgradeToVehicle = "C_Hatchback_01_EPOCH1";
-		};
-		class C_Hatchback_02_EPOCH: C_Hatchback_01_EPOCH	{	upgradeToVehicle = "C_Hatchback_02_EPOCH1";	};
-		class C_Offroad_01_EPOCH: C_Hatchback_01_EPOCH		{	upgradeToVehicle = "C_Offroad_01_EPOCH1";	};
-		class C_SUV_01_EPOCH: C_Hatchback_01_EPOCH			{	upgradeToVehicle = "C_SUV_01_EPOCH1";		};
-		class B_MRAP_01_EPOCH: C_Hatchback_01_EPOCH			{	upgradeToVehicle = "B_MRAP_01_EPOCH1";		};
-		class O_MRAP_02_EPOCH: C_Hatchback_01_EPOCH			{	upgradeToVehicle = "O_MRAP_02_EPOCH1";		};
-		class I_MRAP_03_EPOCH: C_Hatchback_01_EPOCH			{	upgradeToVehicle = "I_MRAP_03_EPOCH1";		};
-	};
-	class KitVehicleUpgradeI_200_EPOCH
-	{
-		class C_Hatchback_01_EPOCH
+		upgradeToVehicle[] = {"C_Hatchback_01_EPOCH1"};
+		class C_Hatchback_01_EPOCH1
 		{
 			ReqMaterials[] = {{1,"KitVehicleUpgradeI_200_EPOCH"}};
-			upgradeToVehicle = "C_Hatchback_01_EPOCH1";
 		};
-		class C_Hatchback_02_EPOCH: C_Hatchback_01_EPOCH	{	upgradeToVehicle = "C_Hatchback_02_EPOCH1";	};
-		class C_Offroad_01_EPOCH: C_Hatchback_01_EPOCH		{	upgradeToVehicle = "C_Offroad_01_EPOCH1";	};
-		class C_SUV_01_EPOCH: C_Hatchback_01_EPOCH			{	upgradeToVehicle = "C_SUV_01_EPOCH1";		};
-		class B_MRAP_01_EPOCH: C_Hatchback_01_EPOCH			{	upgradeToVehicle = "B_MRAP_01_EPOCH1";		};
-		class O_MRAP_02_EPOCH: C_Hatchback_01_EPOCH			{	upgradeToVehicle = "O_MRAP_02_EPOCH1";		};
-		class I_MRAP_03_EPOCH: C_Hatchback_01_EPOCH			{	upgradeToVehicle = "I_MRAP_03_EPOCH1";		};
+		class C_Hatchback_02_EPOCH1: C_Hatchback_01_EPOCH1 {};
+		class C_Offroad_01_EPOCH1: C_Hatchback_01_EPOCH1 {};
+		class C_SUV_01_EPOCH1: C_Hatchback_01_EPOCH1 {};
+		class B_MRAP_01_EPOCH1: C_Hatchback_01_EPOCH1 {};
+		class O_MRAP_02_EPOCH1: C_Hatchback_01_EPOCH1 {};
+		class I_MRAP_03_EPOCH1: C_Hatchback_01_EPOCH1 {};
 	};
-	class KitVehicleUpgradeI_300_EPOCH
+	class C_Hatchback_02_EPOCH: C_Hatchback_01_EPOCH	{	upgradeToVehicle[] = {"C_Hatchback_02_EPOCH1"};	};
+	class C_Offroad_01_EPOCH: C_Hatchback_01_EPOCH		{	upgradeToVehicle[] = {"C_Offroad_01_EPOCH1"};	};
+	class C_SUV_01_EPOCH: C_Hatchback_01_EPOCH			{	upgradeToVehicle[] = {"C_SUV_01_EPOCH1"};		};
+	class B_MRAP_01_EPOCH: C_Hatchback_01_EPOCH			{	upgradeToVehicle[] = {"B_MRAP_01_EPOCH1"};		};
+	class O_MRAP_02_EPOCH: C_Hatchback_01_EPOCH			{	upgradeToVehicle[] = {"O_MRAP_02_EPOCH1"};		};
+	class I_MRAP_03_EPOCH: C_Hatchback_01_EPOCH			{	upgradeToVehicle[] = {"I_MRAP_03_EPOCH1"};		};
+	
+	class C_Hatchback_01_EPOCH1
 	{
-		class C_Hatchback_01_EPOCH
-		{
-			ReqMaterials[] = {{1,"KitVehicleUpgradeI_300_EPOCH"}};
-			upgradeToVehicle = "C_Hatchback_01_EPOCH1";
-		};
-		class C_Hatchback_02_EPOCH: C_Hatchback_01_EPOCH	{	upgradeToVehicle = "C_Hatchback_02_EPOCH1";	};
-		class C_Offroad_01_EPOCH: C_Hatchback_01_EPOCH		{	upgradeToVehicle = "C_Offroad_01_EPOCH1";	};
-		class C_SUV_01_EPOCH: C_Hatchback_01_EPOCH			{	upgradeToVehicle = "C_SUV_01_EPOCH1";		};
-		class B_MRAP_01_EPOCH: C_Hatchback_01_EPOCH			{	upgradeToVehicle = "B_MRAP_01_EPOCH1";		};
-		class O_MRAP_02_EPOCH: C_Hatchback_01_EPOCH			{	upgradeToVehicle = "O_MRAP_02_EPOCH1";		};
-		class I_MRAP_03_EPOCH: C_Hatchback_01_EPOCH			{	upgradeToVehicle = "I_MRAP_03_EPOCH1";		};
-	};
-	class ItemVehDoc2
-	{
-		class C_Hatchback_01_EPOCH1
-		{
-			ReqMaterials[] = {{1,"ItemVehDoc2"},{2,"SpareTire"},{2,"KitTankTrap"}};
-			upgradeToVehicle = "C_Hatchback_01_EPOCH2";
-		};
-		class C_Hatchback_02_EPOCH1: C_Hatchback_01_EPOCH1		{	upgradeToVehicle = "C_Hatchback_02_EPOCH2";	};
-		class C_Offroad_01_EPOCH1: C_Hatchback_01_EPOCH1		{	upgradeToVehicle = "C_Offroad_01_EPOCH2";	};
-		class C_SUV_01_EPOCH1: C_Hatchback_01_EPOCH1			{	upgradeToVehicle = "C_SUV_01_EPOCH2";		};
-		class B_MRAP_01_EPOCH1: C_Hatchback_01_EPOCH1			{	upgradeToVehicle = "B_MRAP_01_EPOCH2";		};
-		class O_MRAP_02_EPOCH1: C_Hatchback_01_EPOCH1			{	upgradeToVehicle = "O_MRAP_02_EPOCH2";		};
-		class I_MRAP_03_EPOCH1: C_Hatchback_01_EPOCH1			{	upgradeToVehicle = "I_MRAP_03_EPOCH2";		};
-	};
-	class KitVehicleUpgradeII_100_EPOCH
-	{
-		class C_Hatchback_01_EPOCH1
-		{
-			ReqMaterials[] = {{1,"KitVehicleUpgradeII_100_EPOCH"}};
-			upgradeToVehicle = "C_Hatchback_01_EPOCH2";
-		};
-		class C_Hatchback_02_EPOCH1: C_Hatchback_01_EPOCH1		{	upgradeToVehicle = "C_Hatchback_02_EPOCH2";	};
-		class C_Offroad_01_EPOCH1: C_Hatchback_01_EPOCH1		{	upgradeToVehicle = "C_Offroad_01_EPOCH2";	};
-		class C_SUV_01_EPOCH1: C_Hatchback_01_EPOCH1			{	upgradeToVehicle = "C_SUV_01_EPOCH2";		};
-		class B_MRAP_01_EPOCH1: C_Hatchback_01_EPOCH1			{	upgradeToVehicle = "B_MRAP_01_EPOCH2";		};
-		class O_MRAP_02_EPOCH1: C_Hatchback_01_EPOCH1			{	upgradeToVehicle = "O_MRAP_02_EPOCH2";		};
-		class I_MRAP_03_EPOCH1: C_Hatchback_01_EPOCH1			{	upgradeToVehicle = "I_MRAP_03_EPOCH2";		};
-	};
-	class KitVehicleUpgradeII_200_EPOCH
-	{
-		class C_Hatchback_01_EPOCH1
+		upgradeToVehicle[] = {"C_Hatchback_01_EPOCH2"};
+		class C_Hatchback_01_EPOCH2
 		{
 			ReqMaterials[] = {{1,"KitVehicleUpgradeII_200_EPOCH"}};
-			upgradeToVehicle = "C_Hatchback_01_EPOCH2";
 		};
-		class C_Hatchback_02_EPOCH1: C_Hatchback_01_EPOCH1		{	upgradeToVehicle = "C_Hatchback_02_EPOCH2";	};
-		class C_Offroad_01_EPOCH1: C_Hatchback_01_EPOCH1		{	upgradeToVehicle = "C_Offroad_01_EPOCH2";	};
-		class C_SUV_01_EPOCH1: C_Hatchback_01_EPOCH1			{	upgradeToVehicle = "C_SUV_01_EPOCH2";		};
-		class B_MRAP_01_EPOCH1: C_Hatchback_01_EPOCH1			{	upgradeToVehicle = "B_MRAP_01_EPOCH2";		};
-		class O_MRAP_02_EPOCH1: C_Hatchback_01_EPOCH1			{	upgradeToVehicle = "O_MRAP_02_EPOCH2";		};
-		class I_MRAP_03_EPOCH1: C_Hatchback_01_EPOCH1			{	upgradeToVehicle = "I_MRAP_03_EPOCH2";		};
+		class C_Hatchback_02_EPOCH2: C_Hatchback_01_EPOCH2 {};
+		class C_Offroad_01_EPOCH2: C_Hatchback_01_EPOCH2 {};
+		class C_SUV_01_EPOCH2: C_Hatchback_01_EPOCH2 {};
+		class B_MRAP_01_EPOCH2: C_Hatchback_01_EPOCH2 {};
+		class O_MRAP_02_EPOCH2: C_Hatchback_01_EPOCH2 {};
+		class I_MRAP_03_EPOCH2: C_Hatchback_01_EPOCH2 {};
 	};
-	class KitVehicleUpgradeII_300_EPOCH
+	class C_Hatchback_02_EPOCH1: C_Hatchback_01_EPOCH1	{	upgradeToVehicle[] = {"C_Hatchback_02_EPOCH2"};	};
+	class C_Offroad_01_EPOCH1: C_Hatchback_01_EPOCH1	{	upgradeToVehicle[] = {"C_Offroad_01_EPOCH2"};	};
+	class C_SUV_01_EPOCH1: C_Hatchback_01_EPOCH1		{	upgradeToVehicle[] = {"C_SUV_01_EPOCH2"};		};
+	class B_MRAP_01_EPOCH1: C_Hatchback_01_EPOCH1		{	upgradeToVehicle[] = {"B_MRAP_01_EPOCH2"};		};
+	class O_MRAP_02_EPOCH1: C_Hatchback_01_EPOCH1		{	upgradeToVehicle[] = {"O_MRAP_02_EPOCH2"};		};
+	class I_MRAP_03_EPOCH1: C_Hatchback_01_EPOCH1		{	upgradeToVehicle[] = {"I_MRAP_03_EPOCH2"};		};
+	
+	class C_Hatchback_01_EPOCH2
 	{
-		class C_Hatchback_01_EPOCH1
-		{
-			ReqMaterials[] = {{1,"KitVehicleUpgradeII_300_EPOCH"}};
-			upgradeToVehicle = "C_Hatchback_01_EPOCH2";
-		};
-		class C_Hatchback_02_EPOCH1: C_Hatchback_01_EPOCH1		{	upgradeToVehicle = "C_Hatchback_02_EPOCH2";	};
-		class C_Offroad_01_EPOCH1: C_Hatchback_01_EPOCH1		{	upgradeToVehicle = "C_Offroad_01_EPOCH2";	};
-		class C_SUV_01_EPOCH1: C_Hatchback_01_EPOCH1			{	upgradeToVehicle = "C_SUV_01_EPOCH2";		};
-		class B_MRAP_01_EPOCH1: C_Hatchback_01_EPOCH1			{	upgradeToVehicle = "B_MRAP_01_EPOCH2";		};
-		class O_MRAP_02_EPOCH1: C_Hatchback_01_EPOCH1			{	upgradeToVehicle = "O_MRAP_02_EPOCH2";		};
-		class I_MRAP_03_EPOCH1: C_Hatchback_01_EPOCH1			{	upgradeToVehicle = "I_MRAP_03_EPOCH2";		};
-	};
-	class ItemVehDoc3
-	{
-		class C_Hatchback_01_EPOCH2
-		{
-			ReqMaterials[] = {{1,"ItemVehDoc3"},{2,"ItemPipe"},{2,"KitShelf"}};
-			upgradeToVehicle = "C_Hatchback_01_EPOCH3";
-		};
-		class C_Hatchback_02_EPOCH2: C_Hatchback_01_EPOCH2		{	upgradeToVehicle = "C_Hatchback_02_EPOCH3";	};
-		class C_Offroad_01_EPOCH2: C_Hatchback_01_EPOCH2		{	upgradeToVehicle = "C_Offroad_01_EPOCH3";	};
-		class C_SUV_01_EPOCH2: C_Hatchback_01_EPOCH2			{	upgradeToVehicle = "C_SUV_01_EPOCH3";		};
-		class B_MRAP_01_EPOCH2: C_Hatchback_01_EPOCH2			{	upgradeToVehicle = "B_MRAP_01_EPOCH3";		};
-		class O_MRAP_02_EPOCH2: C_Hatchback_01_EPOCH2			{	upgradeToVehicle = "O_MRAP_02_EPOCH3";		};
-		class I_MRAP_03_EPOCH2: C_Hatchback_01_EPOCH2			{	upgradeToVehicle = "I_MRAP_03_EPOCH3";		};
-		class C_Van_01_box_EPOCH: C_Hatchback_01_EPOCH2			{	upgradeToVehicle = "C_Van_01_box_EPOCH3";	};
-		class C_Van_01_transport_EPOCH: C_Hatchback_01_EPOCH2	
-		{
-			ReqMaterials[] = {{1,"ItemVehDoc3"},{5,"ItemCorrugatedLg"},{8,"ItemPipe"},{4,"KitShelf"}};
-			upgradeToVehicle = "C_Van_01_transport_EPOCH3";
-		};
-		class O_Truck_02_covered_EPOCH: C_Hatchback_01_EPOCH2			{	upgradeToVehicle = "O_Truck_02_covered_EPOCH3";	};
-		class O_Truck_02_transport_EPOCH: C_Hatchback_01_EPOCH2	
-		{
-			ReqMaterials[] = {{1,"ItemVehDoc3"},{6,"ItemBurlap"},{6,"ItemPipe"},{4,"KitShelf"}};
-			upgradeToVehicle = "O_Truck_02_transport_EPOCH3";
-		};
-	};
-	class KitVehicleUpgradeIII_100_EPOCH
-	{
-		class C_Hatchback_01_EPOCH2
-		{
-			ReqMaterials[] = {{1,"KitVehicleUpgradeIII_100_EPOCH"}};
-			upgradeToVehicle = "C_Hatchback_01_EPOCH3";
-		};
-		class C_Hatchback_02_EPOCH2: C_Hatchback_01_EPOCH2		{	upgradeToVehicle = "C_Hatchback_02_EPOCH3";	};
-		class C_Offroad_01_EPOCH2: C_Hatchback_01_EPOCH2		{	upgradeToVehicle = "C_Offroad_01_EPOCH3";	};
-		class C_SUV_01_EPOCH2: C_Hatchback_01_EPOCH2			{	upgradeToVehicle = "C_SUV_01_EPOCH3";		};
-		class B_MRAP_01_EPOCH2: C_Hatchback_01_EPOCH2			{	upgradeToVehicle = "B_MRAP_01_EPOCH3";		};
-		class O_MRAP_02_EPOCH2: C_Hatchback_01_EPOCH2			{	upgradeToVehicle = "O_MRAP_02_EPOCH3";		};
-		class I_MRAP_03_EPOCH2: C_Hatchback_01_EPOCH2			{	upgradeToVehicle = "I_MRAP_03_EPOCH3";		};
-		class C_Van_01_box_EPOCH: C_Hatchback_01_EPOCH2			{	upgradeToVehicle = "C_Van_01_box_EPOCH3";	};
-		class C_Van_01_transport_EPOCH: C_Hatchback_01_EPOCH2	
-		{
-			ReqMaterials[] = {{1,"KitVehicleUpgradeIII_100_EPOCH"},{5,"ItemCorrugatedLg"},{6,"ItemPipe"},{2,"KitShelf"}};
-			upgradeToVehicle = "C_Van_01_transport_EPOCH3";
-		};
-		class O_Truck_02_covered_EPOCH: C_Hatchback_01_EPOCH2			{	upgradeToVehicle = "O_Truck_02_covered_EPOCH3";	};
-		class O_Truck_02_transport_EPOCH: C_Hatchback_01_EPOCH2	
-		{
-			ReqMaterials[] = {{1,"KitVehicleUpgradeIII_100_EPOCH"},{6,"ItemBurlap"},{4,"ItemPipe"},{2,"KitShelf"}};
-			upgradeToVehicle = "O_Truck_02_transport_EPOCH3";
-		};
-	};
-	class KitVehicleUpgradeIII_200_EPOCH
-	{
-		class C_Hatchback_01_EPOCH2
+		upgradeToVehicle[] = {"C_Hatchback_01_EPOCH3"};
+		class C_Hatchback_01_EPOCH3
 		{
 			ReqMaterials[] = {{1,"KitVehicleUpgradeIII_200_EPOCH"}};
-			upgradeToVehicle = "C_Hatchback_01_EPOCH3";
 		};
-		class C_Hatchback_02_EPOCH2: C_Hatchback_01_EPOCH2		{	upgradeToVehicle = "C_Hatchback_02_EPOCH3";	};
-		class C_Offroad_01_EPOCH2: C_Hatchback_01_EPOCH2		{	upgradeToVehicle = "C_Offroad_01_EPOCH3";	};
-		class C_SUV_01_EPOCH2: C_Hatchback_01_EPOCH2			{	upgradeToVehicle = "C_SUV_01_EPOCH3";		};
-		class B_MRAP_01_EPOCH2: C_Hatchback_01_EPOCH2			{	upgradeToVehicle = "B_MRAP_01_EPOCH3";		};
-		class O_MRAP_02_EPOCH2: C_Hatchback_01_EPOCH2			{	upgradeToVehicle = "O_MRAP_02_EPOCH3";		};
-		class I_MRAP_03_EPOCH2: C_Hatchback_01_EPOCH2			{	upgradeToVehicle = "I_MRAP_03_EPOCH3";		};
-		class C_Van_01_box_EPOCH: C_Hatchback_01_EPOCH2			{	upgradeToVehicle = "C_Van_01_box_EPOCH3";	};
-		class C_Van_01_transport_EPOCH: C_Hatchback_01_EPOCH2	
-		{
-			ReqMaterials[] = {{1,"KitVehicleUpgradeIII_200_EPOCH"},{5,"ItemCorrugatedLg"},{6,"ItemPipe"},{2,"KitShelf"}};
-			upgradeToVehicle = "C_Van_01_transport_EPOCH3";
-		};
-		class O_Truck_02_covered_EPOCH: C_Hatchback_01_EPOCH2			{	upgradeToVehicle = "O_Truck_02_covered_EPOCH3";	};
-		class O_Truck_02_transport_EPOCH: C_Hatchback_01_EPOCH2	
-		{
-			ReqMaterials[] = {{1,"KitVehicleUpgradeIII_100_EPOCH"},{6,"ItemBurlap"},{4,"ItemPipe"},{2,"KitShelf"}};
-			upgradeToVehicle = "O_Truck_02_transport_EPOCH3";
-		};
+		class C_Hatchback_02_EPOCH3: C_Hatchback_01_EPOCH3 {};
+		class C_Offroad_01_EPOCH3: C_Hatchback_01_EPOCH3 {};
+		class C_SUV_01_EPOCH3: C_Hatchback_01_EPOCH3 {};
+		class B_MRAP_01_EPOCH3: C_Hatchback_01_EPOCH3 {};
+		class O_MRAP_02_EPOCH3: C_Hatchback_01_EPOCH3 {};
+		class I_MRAP_03_EPOCH3: C_Hatchback_01_EPOCH3 {};
 	};
-	class KitVehicleUpgradeIII_300_EPOCH
+	class C_Hatchback_02_EPOCH2: C_Hatchback_01_EPOCH2	{	upgradeToVehicle[] = {"C_Hatchback_02_EPOCH3"};	};
+	class C_Offroad_01_EPOCH2: C_Hatchback_01_EPOCH2	{	upgradeToVehicle[] = {"C_Offroad_01_EPOCH3"};	};
+	class C_SUV_01_EPOCH2: C_Hatchback_01_EPOCH2		{	upgradeToVehicle[] = {"C_SUV_01_EPOCH3"};		};
+	class B_MRAP_01_EPOCH2: C_Hatchback_01_EPOCH2		{	upgradeToVehicle[] = {"B_MRAP_01_EPOCH3"};		};
+	class O_MRAP_02_EPOCH2: C_Hatchback_01_EPOCH2		{	upgradeToVehicle[] = {"O_MRAP_02_EPOCH3"};		};
+	class I_MRAP_03_EPOCH2: C_Hatchback_01_EPOCH2		{	upgradeToVehicle[] = {"I_MRAP_03_EPOCH3"};		};
+	
+	class C_Hatchback_01_EPOCH3
 	{
-		class C_Hatchback_01_EPOCH2
-		{
-			ReqMaterials[] = {{1,"KitVehicleUpgradeIII_300_EPOCH"}};
-			upgradeToVehicle = "C_Hatchback_01_EPOCH3";
-		};
-		class C_Hatchback_02_EPOCH2: C_Hatchback_01_EPOCH2		{	upgradeToVehicle = "C_Hatchback_02_EPOCH3";	};
-		class C_Offroad_01_EPOCH2: C_Hatchback_01_EPOCH2		{	upgradeToVehicle = "C_Offroad_01_EPOCH3";	};
-		class C_SUV_01_EPOCH2: C_Hatchback_01_EPOCH2			{	upgradeToVehicle = "C_SUV_01_EPOCH3";		};
-		class B_MRAP_01_EPOCH2: C_Hatchback_01_EPOCH2			{	upgradeToVehicle = "B_MRAP_01_EPOCH3";		};
-		class O_MRAP_02_EPOCH2: C_Hatchback_01_EPOCH2			{	upgradeToVehicle = "O_MRAP_02_EPOCH3";		};
-		class I_MRAP_03_EPOCH2: C_Hatchback_01_EPOCH2			{	upgradeToVehicle = "I_MRAP_03_EPOCH3";		};
-		class C_Van_01_box_EPOCH: C_Hatchback_01_EPOCH2			{	upgradeToVehicle = "C_Van_01_box_EPOCH3";	};
-		class C_Van_01_transport_EPOCH: C_Hatchback_01_EPOCH2	
-		{
-			ReqMaterials[] = {{1,"KitVehicleUpgradeIII_300_EPOCH"},{5,"ItemCorrugatedLg"},{6,"ItemPipe"},{2,"KitShelf"}};
-			upgradeToVehicle = "C_Van_01_transport_EPOCH3";
-		};
-		class O_Truck_02_covered_EPOCH: C_Hatchback_01_EPOCH2			{	upgradeToVehicle = "O_Truck_02_covered_EPOCH3";	};
-		class O_Truck_02_transport_EPOCH: C_Hatchback_01_EPOCH2	
-		{
-			ReqMaterials[] = {{1,"KitVehicleUpgradeIII_100_EPOCH"},{6,"ItemBurlap"},{4,"ItemPipe"},{2,"KitShelf"}};
-			upgradeToVehicle = "O_Truck_02_transport_EPOCH3";
-		};
-	};
-	class ItemVehDoc4
-	{
-		class C_Hatchback_01_EPOCH3
-		{
-			ReqMaterials[] = {{1,"ItemVehDoc3"},{1,"CircuitParts"},{2,"ItemScraps"},{2,"jerrycan_epoch"}};
-			upgradeToVehicle = "C_Hatchback_01_EPOCH4";
-		};
-		class C_Hatchback_02_EPOCH3: C_Hatchback_01_EPOCH3		{	upgradeToVehicle = "C_Hatchback_02_EPOCH4";	};
-		class C_Offroad_01_EPOCH3: C_Hatchback_01_EPOCH3		{	upgradeToVehicle = "C_Offroad_01_EPOCH4";	};
-		class C_SUV_01_EPOCH3: C_Hatchback_01_EPOCH3			{	upgradeToVehicle = "C_SUV_01_EPOCH4";		};
-		class B_MRAP_01_EPOCH3: C_Hatchback_01_EPOCH3			{	upgradeToVehicle = "B_MRAP_01_EPOCH4";		};
-		class O_MRAP_02_EPOCH3: C_Hatchback_01_EPOCH3			{	upgradeToVehicle = "O_MRAP_02_EPOCH4";		};
-		class I_MRAP_03_EPOCH3: C_Hatchback_01_EPOCH3			{	upgradeToVehicle = "I_MRAP_03_EPOCH4";		};
-		class C_Van_01_box_EPOCH3: C_Hatchback_01_EPOCH3		{	upgradeToVehicle = "C_Van_01_box_EPOCH4";	};
-		class C_Van_01_transport_EPOCH3: C_Hatchback_01_EPOCH3	{	upgradeToVehicle = "C_Van_01_transport_EPOCH4";	};
-		class O_Truck_02_covered_EPOCH3: C_Hatchback_01_EPOCH3	{	upgradeToVehicle = "O_Truck_02_covered_EPOCH4";	};
-		class O_Truck_02_transport_EPOCH3: C_Hatchback_01_EPOCH3 {	upgradeToVehicle = "O_Truck_02_transport_EPOCH4"; };
-	};
-	class KitVehicleUpgradeIV_100_EPOCH
-	{
-		class C_Hatchback_01_EPOCH3
-		{
-			ReqMaterials[] = {{1,"KitVehicleUpgradeIV_100_EPOCH"}};
-			upgradeToVehicle = "C_Hatchback_01_EPOCH4";
-		};
-		class C_Hatchback_02_EPOCH3: C_Hatchback_01_EPOCH3		{	upgradeToVehicle = "C_Hatchback_02_EPOCH4";	};
-		class C_Offroad_01_EPOCH3: C_Hatchback_01_EPOCH3		{	upgradeToVehicle = "C_Offroad_01_EPOCH4";	};
-		class C_SUV_01_EPOCH3: C_Hatchback_01_EPOCH3			{	upgradeToVehicle = "C_SUV_01_EPOCH4";		};
-		class B_MRAP_01_EPOCH3: C_Hatchback_01_EPOCH3			{	upgradeToVehicle = "B_MRAP_01_EPOCH4";		};
-		class O_MRAP_02_EPOCH3: C_Hatchback_01_EPOCH3			{	upgradeToVehicle = "O_MRAP_02_EPOCH4";		};
-		class I_MRAP_03_EPOCH3: C_Hatchback_01_EPOCH3			{	upgradeToVehicle = "I_MRAP_03_EPOCH4";		};
-		class C_Van_01_box_EPOCH3: C_Hatchback_01_EPOCH3		{	upgradeToVehicle = "C_Van_01_box_EPOCH4";	};
-		class C_Van_01_transport_EPOCH3: C_Hatchback_01_EPOCH3	{	upgradeToVehicle = "C_Van_01_transport_EPOCH4";	};
-		class O_Truck_02_covered_EPOCH3: C_Hatchback_01_EPOCH3	{	upgradeToVehicle = "O_Truck_02_covered_EPOCH4";	};
-		class O_Truck_02_transport_EPOCH3: C_Hatchback_01_EPOCH3 {	upgradeToVehicle = "O_Truck_02_transport_EPOCH4"; };
-	};
-	class KitVehicleUpgradeIV_200_EPOCH
-	{
-		class C_Hatchback_01_EPOCH3
+		upgradeToVehicle[] = {"C_Hatchback_01_EPOCH4"};
+		class C_Hatchback_01_EPOCH4
 		{
 			ReqMaterials[] = {{1,"KitVehicleUpgradeIV_200_EPOCH"}};
-			upgradeToVehicle = "C_Hatchback_01_EPOCH4";
 		};
-		class C_Hatchback_02_EPOCH3: C_Hatchback_01_EPOCH3		{	upgradeToVehicle = "C_Hatchback_02_EPOCH4";	};
-		class C_Offroad_01_EPOCH3: C_Hatchback_01_EPOCH3		{	upgradeToVehicle = "C_Offroad_01_EPOCH4";	};
-		class C_SUV_01_EPOCH3: C_Hatchback_01_EPOCH3			{	upgradeToVehicle = "C_SUV_01_EPOCH4";		};
-		class B_MRAP_01_EPOCH3: C_Hatchback_01_EPOCH3			{	upgradeToVehicle = "B_MRAP_01_EPOCH4";		};
-		class O_MRAP_02_EPOCH3: C_Hatchback_01_EPOCH3			{	upgradeToVehicle = "O_MRAP_02_EPOCH4";		};
-		class I_MRAP_03_EPOCH3: C_Hatchback_01_EPOCH3			{	upgradeToVehicle = "I_MRAP_03_EPOCH4";		};
-		class C_Van_01_box_EPOCH3: C_Hatchback_01_EPOCH3		{	upgradeToVehicle = "C_Van_01_box_EPOCH4";	};
-		class C_Van_01_transport_EPOCH3: C_Hatchback_01_EPOCH3	{	upgradeToVehicle = "C_Van_01_transport_EPOCH4";	};
-		class O_Truck_02_covered_EPOCH3: C_Hatchback_01_EPOCH3	{	upgradeToVehicle = "O_Truck_02_covered_EPOCH4";	};
-		class O_Truck_02_transport_EPOCH3: C_Hatchback_01_EPOCH3 {	upgradeToVehicle = "O_Truck_02_transport_EPOCH4"; };
+		class C_Hatchback_02_EPOCH4: C_Hatchback_01_EPOCH4 {};
+		class C_Offroad_01_EPOCH4: C_Hatchback_01_EPOCH4 {};
+		class C_SUV_01_EPOCH4: C_Hatchback_01_EPOCH4 {};
+		class B_MRAP_01_EPOCH4: C_Hatchback_01_EPOCH4 {};
+		class O_MRAP_02_EPOCH4: C_Hatchback_01_EPOCH4 {};
+		class I_MRAP_03_EPOCH4: C_Hatchback_01_EPOCH4 {};
 	};
-	class KitVehicleUpgradeIV_300_EPOCH
+	class C_Hatchback_02_EPOCH3: C_Hatchback_01_EPOCH3	{	upgradeToVehicle[] = {"C_Hatchback_02_EPOCH4"};	};
+	class C_Offroad_01_EPOCH3: C_Hatchback_01_EPOCH3	{	upgradeToVehicle[] = {"C_Offroad_01_EPOCH4"};	};
+	class C_SUV_01_EPOCH3: C_Hatchback_01_EPOCH3		{	upgradeToVehicle[] = {"C_SUV_01_EPOCH4"};		};
+	class B_MRAP_01_EPOCH3: C_Hatchback_01_EPOCH3		{	upgradeToVehicle[] = {"B_MRAP_01_EPOCH4"};		};
+	class O_MRAP_02_EPOCH3: C_Hatchback_01_EPOCH3		{	upgradeToVehicle[] = {"O_MRAP_02_EPOCH4"};		};
+	class I_MRAP_03_EPOCH3: C_Hatchback_01_EPOCH3		{	upgradeToVehicle[] = {"I_MRAP_03_EPOCH4"};		};
+
+	class K01
 	{
-		class C_Hatchback_01_EPOCH3
-		{
-			ReqMaterials[] = {{1,"KitVehicleUpgradeIV_300_EPOCH"}};
-			upgradeToVehicle = "C_Hatchback_01_EPOCH4";
-		};
-		class C_Hatchback_02_EPOCH3: C_Hatchback_01_EPOCH3		{	upgradeToVehicle = "C_Hatchback_02_EPOCH4";	};
-		class C_Offroad_01_EPOCH3: C_Hatchback_01_EPOCH3		{	upgradeToVehicle = "C_Offroad_01_EPOCH4";	};
-		class C_SUV_01_EPOCH3: C_Hatchback_01_EPOCH3			{	upgradeToVehicle = "C_SUV_01_EPOCH4";		};
-		class B_MRAP_01_EPOCH3: C_Hatchback_01_EPOCH3			{	upgradeToVehicle = "B_MRAP_01_EPOCH4";		};
-		class O_MRAP_02_EPOCH3: C_Hatchback_01_EPOCH3			{	upgradeToVehicle = "O_MRAP_02_EPOCH4";		};
-		class I_MRAP_03_EPOCH3: C_Hatchback_01_EPOCH3			{	upgradeToVehicle = "I_MRAP_03_EPOCH4";		};
-		class C_Van_01_box_EPOCH3: C_Hatchback_01_EPOCH3		{	upgradeToVehicle = "C_Van_01_box_EPOCH4";	};
-		class C_Van_01_transport_EPOCH3: C_Hatchback_01_EPOCH3	{	upgradeToVehicle = "C_Van_01_transport_EPOCH4";	};
-		class O_Truck_02_covered_EPOCH3: C_Hatchback_01_EPOCH3	{	upgradeToVehicle = "O_Truck_02_covered_EPOCH4";	};
-		class O_Truck_02_transport_EPOCH3: C_Hatchback_01_EPOCH3 {	upgradeToVehicle = "O_Truck_02_transport_EPOCH4"; };
-	};
-	class ItemVehDocRara 
-	{
-		class K01
+		upgradeToVehicle[] = {"mosquito_epoch"};
+		class mosquito_epoch
 		{
 			ReqMaterials[] = {{1,"ItemVehDocRara"},{2,"PaintCanOra"},{4,"ItemPipe"},{2,"jerrycan_epoch"}};
-			upgradeToVehicle = "mosquito_epoch";
 		};
-		class K02: K01{};
-		class K03: K01{};
-		class K04: K01{};
 	};
+	class K02: K01	{};
+	class K03: K01	{};
+	class K04: K01	{};
+
 	class C_Offroad_01_EPOCH4		
 	{	
-		ReqMaterials[] = {{1,"ItemVehDocRara"},{1,"PaintCanBlu"},{1,"PaintCanRed"},{1,"CircuitParts"},{1,"ItemBattery"}};
-		upgradeToVehicle = "C_Offroad_01_EPOCH5";	
+		upgradeToVehicle[] = {"C_Offroad_01_EPOCH5"};
+		class C_Offroad_01_EPOCH5
+		{
+			ReqMaterials[] = {{1,"ItemVehDocRara"},{1,"PaintCanBlu"},{1,"PaintCanRed"},{1,"CircuitParts"},{1,"ItemBattery"}};
+		};
 	};
 };


### PR DESCRIPTION
- Vehicle Upgrade moved to DynaMenu
- Hitpoints now also will be given to Vehicles from other BaseClasses
(controlled by HitPointNames)
- Added a security Check that Players must have a bit distance to
upgrade
- Fixed some errors in Colorscript for upgraded Vehicles. If it is only
an upgrade, same color is used. If it is another Class, a new random
color will be taken.
- Removed Upgrade Vehicle from Inventory Click
- Changed DynaMenu to make it possible to call a script to get iconpath
(use "iconcode" instead of "icon" then)