### PR TITLE
Temp groups 2

### DIFF
--- a/Sources/epoch_config/Configs/CfgActionMenu/CfgActionMenu_self.hpp
+++ b/Sources/epoch_config/Configs/CfgActionMenu/CfgActionMenu_self.hpp
@@ -44,14 +44,14 @@ class Groups
 	{
 		condition = "true";
 		action = "call EPOCH_Inventory_Group;";
-		icon = "perm_group_menu_ca.paa";//"x\addons\a3_epoch_code\Data\UI\buttons\perm_group_menu_ca.paa";
+		icon = "x\addons\a3_epoch_code\Data\UI\buttons\perm_group_menu_ca.paa";
 		tooltip = "Perm Group Menu";
 	};
 	class TempGroup
 	{
 		condition = "true";
 		action = "call EPOCH_Inventory_TempGroup;";
-		icon = "temp_group_menu_ca.paa";//"x\addons\a3_epoch_code\Data\UI\buttons\temp_group_menu_ca.paa";
+		icon = "x\addons\a3_epoch_code\Data\UI\buttons\temp_group_menu_ca.paa";
 		tooltip = "Temp Group Menu";
 	};
 };

--- a/Sources/epoch_config/Configs/CfgActionMenu/CfgActionMenu_target.hpp
+++ b/Sources/epoch_config/Configs/CfgActionMenu/CfgActionMenu_target.hpp
@@ -504,3 +504,40 @@ class VehMaintanance
 		};
 	};
 };
+
+//Groups
+class Groups
+{
+	condition = "dyna_isPlayer";
+	action = "";
+	icon = "x\addons\a3_epoch_code\Data\UI\buttons\group_menu_ca.paa";
+	tooltip = "Groups Menu";
+	class Group
+	{
+		condition = "dyna_isPlayer";
+		action = "call EPOCH_Inventory_Group;";
+		icon = "x\addons\a3_epoch_code\Data\UI\buttons\perm_group_menu_ca.paa";
+		tooltip = "Perm Group Menu";
+	};
+	class TempGroup
+	{
+		condition = "dyna_isPlayer";
+		action = "call EPOCH_Inventory_TempGroup;";
+		icon = "x\addons\a3_epoch_code\Data\UI\buttons\temp_group_menu_ca.paa";
+		tooltip = "Temp Group Menu";
+	};
+};
+class player_group_requests
+{
+	condition = "dyna_isPlayer && !(Epoch_invited_GroupUIDs isEqualTo[])";
+	action = "call EPOCH_Inventory_iGroup;";
+	icon = "x\addons\a3_epoch_code\Data\UI\buttons\group_requests_ca.paa";
+	tooltip = "Group Requests";
+};
+class player_tempGroup_requests
+{
+	condition = "dyna_isPlayer && !(Epoch_invited_tempGroupUIDs isEqualTo[])";
+	action = "call EPOCH_Inventory_itempGroup;";
+	icon = "x\addons\a3_epoch_code\Data\UI\buttons\group_requests_ca.paa";
+	tooltip = "Temp Group Requests";
+};

--- a/Sources/epoch_server/compile/epoch_grouptemp/EPOCH_server_deleteTempGroup.sqf
+++ b/Sources/epoch_server/compile/epoch_grouptemp/EPOCH_server_deleteTempGroup.sqf
@@ -22,7 +22,7 @@ if !([_player, _token] call EPOCH_server_getPToken) exitWith{};
 _return = false;
 _groupID = getPlayerUID _player;
 if (_groupID != "") then {
-
+	_allPlayers = allPlayers select {alive _x};
 	{
 		_group = grpNull;
 		_permGroup = _x getVariable["GROUP",""];

--- a/Sources/epoch_server/compile/epoch_grouptemp/EPOCH_server_updatePlayerTempGroup.sqf
+++ b/Sources/epoch_server/compile/epoch_grouptemp/EPOCH_server_updatePlayerTempGroup.sqf
@@ -43,10 +43,8 @@ if !(_contentArray isEqualTo []) then {
 			if ((_x getVariable ["TEMPGROUP",""]) != _groupID) then {
 				_group = grpNull;
 				{
-					if ((_x getVariable["TEMPGROUP",""]) == _groupID) exitWith {
-						_group = group _x;
-					};
-				} forEach _allPlayers;
+					_group = group _x;
+				} forEach (_allPlayers select {(_x getVariable["TEMPGROUP", ""]) == _groupID});
 
 				if (isNull _group) then {
 					_group = createGroup [west, true];
@@ -56,6 +54,7 @@ if !(_contentArray isEqualTo []) then {
 				[_x] joinSilent _group;
 			};
 		} forEach (_allPlayers select {getPlayerUID _x == _selectedPlayerUID});
+		
 
 		// find player name from DB
 		if (_selectedPlayerName == "Dead Player") then {
@@ -86,6 +85,7 @@ if !(_contentArray isEqualTo []) then {
 		//Remove
 		_found = false;
 		_group = grpNull;
+		_permGroup = "";
 		{
 			_permGroup = _x getVariable["GROUP",""];
 			_playerObj = _x;
@@ -93,10 +93,8 @@ if !(_contentArray isEqualTo []) then {
 		if !(_permGroup isEqualTo "")then
 		{
 			{
-				if ((_x getVariable["GROUP",""]) == _groupID) exitWith {
-					_group = group _x;
-				};
-			} forEach _allPlayers;
+				_group = group _x;
+			} forEach (_allPlayers select {(_x getVariable["GROUP", ""]) == _permGroup});
 		};
 		_playerObj setVariable ["TEMPGROUP", nil];
 		if (isNull _group) then {


### PR DESCRIPTION
Fix missing _allPlayers variable.
Optimize forEach statements.
Fix use of _groupID instead of _permGroup.
This completes the return to Perm Group once kicked, left or deleting Temp Group when another one of your Group mates are online.

Change link to new group perm and temp paa's to Epoch Core for next pull merge request.

Could not see Group menus or Invitations on DynaMenu if looking at another player. Added all Group and Invitation Menu's to DynaMenu player targets