### PR TITLE
BE filter update favbar kick

### DIFF
--- a/Server_Install_Pack/sc/battleye/scripts.txt
+++ b/Server_Install_Pack/sc/battleye/scripts.txt
@@ -5,7 +5,7 @@
 7 setAmmo
 7 enableFatigue
 7 setUnitRecoilCoefficient
-7 setWeaponReloadingTime !="_unit setWeaponReloadingTime [_unit,_weapon,1];" !="_unit setWeaponReloadingTime [_unit,_weapon,1];" !="uzzle;\nplayer fire [_muzzle, _muzzle, _item];\nplayer setWeaponReloadingTime [player, _muzzle, 0];\n};\n};\ncase 16: \n{	\n_equipped ="
+7 setWeaponReloadingTime !="_unit setWeaponReloadingTime [_unit,_weapon,1];" !="_unit setWeaponReloadingTime [_unit,_weapon,1];" !="uzzle;\nplayer fire [_muzzle, _muzzle, _item];\nplayer setWeaponReloadingTime [player, _muzzle, 0];\n};\n};\ncase 16: \n{\n_equipped ="
 7 allMissionObjects !="_alljammer = allmissionobjects 'PlotPole_EPOCH';"
 7 callExtension
 7 showCommandingMenu !="showCommandingMenu '';" !="showCommandingMenu '#USER:"


### PR DESCRIPTION
A tab was removed from Epoch code.
BE filter change needed.

See this commit for reason:
https://github.com/EpochModTeam/Epoch/commit/52e02b954c93d1ec2bf7ca42ed5d01e8324cdf6e#diff-cc84747d9d3a0156295c4d0393c0d04eR477
