### PR TITLE
Fix for Duping by remove Building

### DIFF
--- a/Sources/epoch_server/compile/epoch_bases/EPOCH_server_removeBUILD.sqf
+++ b/Sources/epoch_server/compile/epoch_bases/EPOCH_server_removeBUILD.sqf
@@ -20,6 +20,8 @@ params ["_building","_player",["_token","",[""]] ];
 if !([_player, _token] call EPOCH_server_getPToken) exitWith{};
 if (isNull _building) exitWith{};
 if (_player distance _building > 20) exitWith{};
+if (_building getvariable ['Build_LockedForRemoving',false]) exitwith {};
+_building setvariable ['Build_LockedForRemoving',true];
 
 // TODO add group check here since this should only be removed by group or owner of pole
 _objType = typeOf _building;


### PR DESCRIPTION
If the Server is high loaded, you can choose "remove" multiple times and the Server run EPOCH_server_removeBUILD multiple at the same time. So let's set a Variable at the beginning of the, because deletevehicle is too slow

Our fix is client side, but needs BE-Filters.
I think Server Side should also work, so lets first try this one.
