### PR TITLE
Fixes and Cleanups for VehRepair + ServicePoint

### DIFF
--- a/Sources/epoch_code/compile/building/EPOCH_upgradeBUILD.sqf
+++ b/Sources/epoch_code/compile/building/EPOCH_upgradeBUILD.sqf
@@ -116,7 +116,7 @@ if (_object isKindOf "Constructions_static_F") then {
 			_canUpgradePartCount = _canUpgradePartCount + _req;
 		} forEach _upgradeParts;
 
-		_doors = ["WoodLargeWallDoorL_EPOCH","WoodWall4_EPOCH"];
+		_doors = ["WoodLargeWallDoorL_EPOCH","WoodWall4_EPOCH","CinderWallDoorwHatch_EPOCH"];
 		_gates = ["CinderWallGarage_EPOCH"];
 		if (_canUpgrade) then {
 			_upgradeto = _upgrade select 0;

--- a/Sources/epoch_code/compile/vehicles/EPOCH_client_VehicleMaintananceCheck.sqf
+++ b/Sources/epoch_code/compile/vehicles/EPOCH_client_VehicleMaintananceCheck.sqf
@@ -12,10 +12,10 @@
     Github:
     https://github.com/EpochModTeam/Epoch/tree/release/Sources/epoch_code/compile/vehicles/EPOCH_client_VehicleMaintananceCheck.sqf
 */
-private ["_veh","_config","_VehicleRepairs","_repairs","_removes","_replaces","_wheels","_wheelcounter","_torepair","_HitPointName","_Hit","_wheel","_repairarrays"];
+private ["_veh","_VehicleRepairs","_EnableRemoveParts","_repairs","_removes","_replaces","_wheels","_wheelcounter","_torepair","_HitPointName","_Hit","_wheel","_repairarrays"];
 _veh = _this;
-_config = 'CfgEpochClient' call EPOCH_returnConfig;
-_VehicleRepairs = getArray (_config >> "VehicleRepairs");
+_VehicleRepairs = ["CfgEpochClient", "VehicleRepairs", []] call EPOCH_fnc_returnConfigEntryV2;
+_EnableRemoveParts = ["CfgEpochClient", "EnableRemoveParts", true] call EPOCH_fnc_returnConfigEntryV2;
 _repairs = [];
 _removes = [];
 _replaces = [];
@@ -42,7 +42,7 @@ _torepair = (getAllHitPointsDamage _veh) select 0;
 			if (_Hit >= _limit1) exitwith {
 				_repairs pushback _searchedhit;
 			};
-			if !((_veh getvariable ["vehicle_slot","-1"]) isequalto "-1") then {
+			if (!((_veh getvariable ["vehicle_slot","-1"]) isequalto "-1") && _EnableRemoveParts) then {
 				if (_searchedhit in ["HitLFWheel","HitLF2Wheel","HitLMWheel","HitLBWheel","HitRFWheel","HitRF2Wheel","HitRMWheel","HitRBWheel","HitEngine"]) then {
 					_removes pushback _searchedhit;
 				};

--- a/Sources/epoch_code/compile/vehicles/EPOCH_client_repairVehicle.sqf
+++ b/Sources/epoch_code/compile/vehicles/EPOCH_client_repairVehicle.sqf
@@ -19,13 +19,9 @@ params ["_vehicle","_value"];
 if (local _vehicle) then {
 	{
 		if ((_x select 0) isequaltype 0) then {
-//			_currentDMG = _vehicle getHitIndex (_x select 0);
-//			_vehicle setHitIndex [_x select 0, (_currentDMG - 0.5) max 0];
 			_vehicle setHitIndex [_x select 0, _x select 1];
 		}
 		else {
-//			_currentDMG = _vehicle getHitPointDamage (_x select 0);
-//			_vehicle setHitPointDamage [_x select 0, (_currentDMG - 0.5) max 0];
 			_vehicle setHitPointDamage [_x select 0, _x select 1];
 		};
 	} foreach _value;

--- a/Sources/epoch_config/Configs/CfgBaseBuilding.hpp
+++ b/Sources/epoch_config/Configs/CfgBaseBuilding.hpp
@@ -289,7 +289,7 @@ class CfgBaseBuilding
     class CinderWallHalf_Ghost_EPOCH : CinderWallHalf_SIM_EPOCH {};
     class CinderWall_EPOCH : Default
     {
-        upgradeBuilding[] = {{"CinderWallGarage_EPOCH",{{"ItemCorrugatedLg",1},{"CircuitParts",1}}}};
+        upgradeBuilding[] = {{"CinderWallGarage_EPOCH",{{"ItemCorrugatedLg",1},{"CircuitParts",1}}},{"CinderWallDoorwHatch_EPOCH",{{"ItemCorrugatedLg",1},{"CircuitParts",1}}}};
         removeParts[] = {{"CinderBlocks",4},{"ItemRock",2}};
         simulClass = "CinderWall_SIM_EPOCH";
         staticClass = "CinderWall_EPOCH";
@@ -304,6 +304,14 @@ class CfgBaseBuilding
         allowedSnapObjects[] = {"Const_Cinder_static_F","Const_floors_static_F"};
         upgradeBuilding[] = {};
         removeParts[] = {};
+    };
+    class CinderWallDoorwHatch_EPOCH : Default
+    {
+        removeParts[] = {{"CinderBlocks",4},{"ItemCorrugatedLg",1},{"CircuitParts",1}};
+        staticClass = "CinderWallDoorwHatch_EPOCH";
+        snapType = "snapPointsPara";
+        snapPointsPara[] = {"N","E","W"};
+        allowedSnapPoints[] = {"N","S","E","W"};
     };
     class WoodLargeWall_EPOCH : Default
     {

--- a/Sources/epoch_config/Configs/CfgEpochClient.hpp
+++ b/Sources/epoch_config/Configs/CfgEpochClient.hpp
@@ -160,6 +160,7 @@ class CfgEpochClient
 
 	// Advanced Vehicle Repair
 	UseAdvancedVehicleRepair = "true";									// Switch On / Off Advanced Vehicle Repair (Does not effect SuppressedCraftingItems !)
+	EnableRemoveParts = "true";											// Enable removing Tires / Engines from Vehicles
 	DisallowSellOnDamage = "false";										// Prevent from selling Vehicles with one or more fully damaged wheel or engine
 	SuppressedCraftingItems[] = {"VehicleRepairLg"};					// These Items can not be crafted (but can be used in recipe) - for usage of "Advanced Vehicle Repair"
 	VehicleRepairs[] = {												// {Hitpoint, dmg to repair, dmg to replace, mat to repair, mat to replace}

--- a/Sources/epoch_config/Configs/CfgServicePoint.hpp
+++ b/Sources/epoch_config/Configs/CfgServicePoint.hpp
@@ -58,6 +58,17 @@ class CfgServicePoint {
 //								"Land_fs_feed_F",
 //								"Land_fs_roof_F"
 	};
+	PreventRepairs[] = {		// These Hitpints will not be repaired, if damage >= value (Prevent from Duping Tires / Engines)
+		{"HitLFWheel",1},		// {"HitPoint",value}
+		{"HitLF2Wheel",1},
+		{"HitLMWheel",1},
+		{"HitLBWheel",1},
+		{"HitRFWheel",1},
+		{"HitRF2Wheel",1},
+		{"HitRMWheel",1},
+		{"HitRBWheel",1},
+		{"HitEngine",1}
+	};
 	ServicePointDist = 40;
 	refuel_updateInterval = 1;
 	refuel_amount = 0.1;

--- a/Sources/epoch_config/Configs/cfgCrafting.hpp
+++ b/Sources/epoch_config/Configs/cfgCrafting.hpp
@@ -367,14 +367,13 @@ class CfgCrafting
     };
     class VehicleRepair : Part
     {
-        usedIn[] = {"VehicleRepairLg","EngineParts","SpareTire"};
+        usedIn[] = {"VehicleRepairLg","EngineParts","SpareTire","KitVehicleUpgradeI_200_EPOCH"};
         previewPosition[] = {0.787659,1,0.30098};
         previewScale = 0.45;
         previewVector = 1.5;
     };
     class VehicleRepairLg : Item
     {
-        usedIn[] = {"KitVehicleUpgradeI_200_EPOCH"};
         recipe[] = {"VehicleRepair","ItemCorrugated"};
         previewPosition[] = {0.798742,1,0.317871};
         previewScale = 0.25;

--- a/Sources/epoch_server/compile/epoch_vehicle/EPOCH_server_repairVehicle.sqf
+++ b/Sources/epoch_server/compile/epoch_vehicle/EPOCH_server_repairVehicle.sqf
@@ -12,6 +12,7 @@
     Github:
     https://github.com/EpochModTeam/Epoch/tree/release/Sources/epoch_server/compile/epoch_vehicle/EPOCH_server_repairVehicle.sqf
 */
+private ["_god"];
 params ["_vehicle","_value","_player",["_token","",[""]]];
 if (isNull _vehicle) exitWith{};
 if !([_player,  _token] call EPOCH_server_getPToken) exitWith{};
@@ -22,6 +23,10 @@ if ((_value select 0) isEqualTo "ALL") then {
 } 
 else {
 	if (local _vehicle) then {
+		_god = !(isDamageAllowed _vehicle);
+		if (_god) then {
+			_vehicle allowdamage true;
+		};
 		{
 			if ((_x select 0) isequaltype 0) then {
 				_vehicle setHitIndex _x;
@@ -30,6 +35,9 @@ else {
 				_vehicle setHitPointDamage _x;
 			};
 		} foreach _value;
+		if (_god) then {
+			_vehicle allowdamage false;
+		};
 	} else {
 		[_vehicle, _value] remoteExec ['EPOCH_client_repairVehicle',_vehicle];
 	};


### PR DESCRIPTION
- Added CinderWall Door to DoorCount in UpgradeBuild
- Added Option to prevent repairing full damaged HitPoints in
ServicePoint
- Added Option to disable removing Parts in Advanced Vehicle Repair
- Added CinderWallDoorwHatch_EPOCH to cfgBaseBuilding
- Fix in cfgCrafting for KitVehicleUpgradeI_200_EPOCH
- Added an "isdamageallowed" check in EPOCH_server_repairVehicle for repairing untouched Vehicles in Bases https://github.com/EpochModTeam/Epoch/blob/experimental/Sources/epoch_server/compile/epoch_vehicle/EPOCH_load_vehicles.sqf#L202-L203
- Some Cleanups of commented out lines