### PR TITLE
Karma

### DIFF
--- a/Sources/epoch_code/init/both_init.sqf
+++ b/Sources/epoch_code/init/both_init.sqf
@@ -78,12 +78,11 @@ EPOCH_customVarCount = count EPOCH_customVars;
 // Init Community Stats
 EPOCH_communityStats = [];
 EPOCH_defaultStatVars = [];
+EPOCH_communityStatsLimits = [];
 _communityStatsInit = ["CfgEpochClient", "defineCommunityStats", []] call EPOCH_fnc_returnConfigEntryV2;
-EPOCH_communityStatsDefaults = _communityStatsInit;
-{
-	EPOCH_communityStats pushBack (_x select 0);
-	EPOCH_defaultStatVars pushBack (_x select 1);
-} forEach _communityStatsInit;
+EPOCH_communityStats = _communityStatsInit apply {_x param [0,""]};
+EPOCH_defaultStatVars = _communityStatsInit apply {_x param [1,0]};
+EPOCH_communityStatsLimits = _communityStatsInit apply {_x param [2,[]]};
 EPOCH_communityStatsCount = count EPOCH_communityStats;
 
 //GroupSize (number) // Price (String)

--- a/Sources/epoch_config/Configs/CfgEpochClient.hpp
+++ b/Sources/epoch_config/Configs/CfgEpochClient.hpp
@@ -120,11 +120,11 @@ class CfgEpochClient
 	};
 	defineCommunityStats[]  = {
 		// EPOCH_total + varName, starting value, {min,max or custom values}
-		{"Karma",1500,{-50000,50000,{-5000,-15000,-30000},{5000,15000,30000}}, // min, max, {Work In Progress levels}
+		{"Karma",1500,{-50000,50000,{-5000,-15000,-30000},{5000,15000,30000}}}, // min, max, {Work In Progress levels}
 		{"Murders",0,{}},
 		{"Deaths",0,{}},
-		{"Suicides",0,{0,99999},500}, // min, max, "Suicide King" status
-		{"Revives",0,{0,99999},500}, // min, max, "Medic" status
+		{"Suicides",0,{0,99999,500}}, // min, max, "Suicide King" status
+		{"Revives",0,{0,99999,500}}, // min, max, "Medic" status
 		{"TraderMissions",0,{}},
 		{"AIKills",0,{}},
 		{"AntagonistKills",0,{}},

--- a/Sources/epoch_config/Configs/CfgEpochClient.hpp
+++ b/Sources/epoch_config/Configs/CfgEpochClient.hpp
@@ -119,12 +119,11 @@ class CfgEpochClient
 		{{"HitPoints","getPlayerHitPointDamage","HitLegs"},"topRight","x\addons\a3_epoch_code\Data\UI\broken_ca.paa"}
 	};
 	defineCommunityStats[]  = {
-		// EPOCH_total + varName, starting value, {min,max or custom values array}
-		{"Karma",0,{-50000,50000}},
+		// EPOCH_total + varName, starting value, {min,max or custom values}
 		{"Murders",0,{}},
 		{"Deaths",0,{}},
-		{"Suicides",0,{}},
-		{"Revives",0,{}},
+		{"Suicides",0,{0,99999},500}, // min, max, "Suicide King" status
+		{"Revives",0,{0,99999},500}, // min, max, "Medic" status
 		{"TraderMissions",0,{}},
 		{"AIKills",0,{}},
 		{"AntagonistKills",0,{}},

--- a/Sources/epoch_config/Configs/CfgEpochClient.hpp
+++ b/Sources/epoch_config/Configs/CfgEpochClient.hpp
@@ -106,8 +106,6 @@ class CfgEpochClient
 		{"Nuisance",0,{100,0}},
 		{"MissionArray",{},{}}
 	};
-	// add any stats and their starting number here for better community integration and neat stats tracking too!
-	defineCommunityStats[]  = {{"Murders",0},{"Deaths",0},{"Suicides",0},{"Revives",0},{"TraderMissions",0},{"AIKills",0},{"AntagonistKills",0},{"ZombieKills",0}};
     hudConfigs[] = {
 		{{"BloodP","","",{"getPlayerDamage",">=",0.7}},"topRight","x\addons\a3_epoch_code\Data\UI\bleeding_ca.paa",{"forceUpdate"}},
 		{{"Oxygen","getPlayerOxygenRemaining","",{},{1,0,2,2,1,0.55}},"topRight","x\addons\a3_epoch_code\Data\UI\oxygen_ca.paa"},
@@ -119,6 +117,18 @@ class CfgEpochClient
 		{"Soiled","topRight","x\addons\a3_epoch_code\Data\UI\soiled_ca.paa"},
 		{"Radiation","topRight","x\addons\a3_epoch_code\Data\UI\rads_ca.paa"},
 		{{"HitPoints","getPlayerHitPointDamage","HitLegs"},"topRight","x\addons\a3_epoch_code\Data\UI\broken_ca.paa"}
+	};
+	defineCommunityStats[]  = {
+		// EPOCH_total + varName, starting value, {min,max or custom values array}
+		{"Karma",0,{-50000,50000}},
+		{"Murders",0,{}},
+		{"Deaths",0,{}},
+		{"Suicides",0,{}},
+		{"Revives",0,{}},
+		{"TraderMissions",0,{}},
+		{"AIKills",0,{}},
+		{"AntagonistKills",0,{}},
+		{"ZombieKills",0,{}}
 	};
     group_upgrade_lvl[] = {4,"1000",6,"1500",8,"2000",10,"2500",12,"3000",14,"3500",16,"4000",32,"8000",64,"16000"}; // controls max group limit and cost
     // Event handler code

--- a/Sources/epoch_config/Configs/CfgEpochClient.hpp
+++ b/Sources/epoch_config/Configs/CfgEpochClient.hpp
@@ -120,6 +120,7 @@ class CfgEpochClient
 	};
 	defineCommunityStats[]  = {
 		// EPOCH_total + varName, starting value, {min,max or custom values}
+		{"Karma",1500,{-50000,50000,{-5000,-15000,-30000},{5000,15000,30000}}, // min, max, {Work In Progress levels}
 		{"Murders",0,{}},
 		{"Deaths",0,{}},
 		{"Suicides",0,{0,99999},500}, // min, max, "Suicide King" status

--- a/Sources/epoch_server/compile/epoch_player/EPOCH_server_deadPlayer.sqf
+++ b/Sources/epoch_server/compile/epoch_player/EPOCH_server_deadPlayer.sqf
@@ -13,7 +13,7 @@
     https://github.com/EpochModTeam/Epoch/tree/release/Sources/epoch_server/compile/epoch_player/EPOCH_server_deadPlayer.sqf
 */
 //[[[cog import generate_private_arrays ]]]
-private ["_bankBalance","_bankData","_cIndex","_current_crypto","_defaultVars","_playerName","_playerUID","_pos","_response","_triggerType","_vars","_killerUID","_deathType","_killerCommunityStats","_mIndex","_current_murders","_communityStats","_sIndex","_current_suicides","_dIndex","_current_deaths","_playerKarmaAdj","_killerKarmaAdj","_kIndex","_playerCStats","_playerKarma","_playerIsNeutral","_playerIsBandit","_playerIsHero","_killerCStats","_killerKarma"];
+private ["_bankBalance","_bankData","_cIndex","_current_crypto","_defaultVars","_playerName","_playerUID","_pos","_response","_triggerType","_vars","_killerUID","_deathType","_killerCommunityStats","_mIndex","_current_murders","_communityStats","_sIndex","_current_suicides","_dIndex","_current_deaths","_playerKarmaAdj","_killerKarmaAdj","_kIndex","_playerCStats","_playerKarma","_playerIsNeutral","_playerIsBandit","_playerIsHero","_killerCStats","_killerKarma","_karmaLimitsArray","_lowKarmaLevel1","_highKarmaLevel1"];
 //[[[end]]]
 params ["_playerObj","_killer","_playerName",["_token","",[""]] ];
 
@@ -28,9 +28,15 @@ _pos = getposATL _playerObj;
 _kIndex = EPOCH_communityStats find "Karma";
 _playerCStats = _playerObj getVariable["COMMUNITY_STATS", EPOCH_defaultStatVars];
 _playerKarma = _playerCStats select _kIndex;
-_playerIsNeutral = (_playerKarma < 5000 && _playerKarma > -5000);
-_playerIsBandit = (_playerKarma <= -5000);
-_playerIsHero = (_playerKarma >= 5000);
+
+// set config karma levels
+_karmaLimitsArray = EPOCH_communityStatsLimits select _kIndex;
+_lowKarmaLevel1 = ((_karmaLimitsArray select 2) select 0);
+_highKarmaLevel1 = ((_karmaLimitsArray select 3) select 0);
+
+_playerIsNeutral = (_playerKarma < _highKarmaLevel1 && _playerKarma > _lowKarmaLevel1);
+_playerIsBandit = (_playerKarma <= _lowKarmaLevel1);
+_playerIsHero = (_playerKarma >= _highKarmaLevel1);
 
 // default deathType is suicide
 _deathType = 666;
@@ -67,17 +73,17 @@ if (_playerObj != _killer) then {
 		
 		// killer karma changes
 		_killerKarmaAdj = -5;
-		if(_killerKarma < 5000 && _killerKarma > -5000)then{
+		if(_killerKarma < _highKarmaLevel1 && _killerKarma > _lowKarmaLevel1)then{
 			if(_playerIsNeutral)then{_killerKarmaAdj = abs((-_killerKarma) * 0.03) + _playerKarmaAdj};
 			if(_playerIsBandit)then{_killerKarmaAdj = abs((_killerKarma) * 0.05) + _playerKarmaAdj};
 			if(_playerIsHero)then{_killerKarmaAdj = abs((-_killerKarma) * 0.025) + _playerKarmaAdj};
 		};
-		if(_killerKarma <= -5000)then{
+		if(_killerKarma <= _lowKarmaLevel1)then{
 			if(_playerIsNeutral)then{_killerKarmaAdj = abs((_killerKarma) * 0.05) + _playerKarmaAdj};
 			if(_playerIsBandit)then{_killerKarmaAdj = abs((-_killerKarma) * 0.15) + _playerKarmaAdj};
 			if(_playerIsHero)then{_killerKarmaAdj = abs((_killerKarma) * 0.15) + _playerKarmaAdj};
 		};
-		if(_killerKarma >= 5000)then{
+		if(_killerKarma >= _highKarmaLevel1)then{
 			if(_playerIsNeutral)then{_killerKarmaAdj = abs((-_killerKarma) * 0.10) + _playerKarmaAdj};
 			if(_playerIsBandit)then{_killerKarmaAdj = abs((_killerKarma) * 0.15) + _playerKarmaAdj};
 			if(_playerIsHero)then{_killerKarmaAdj = abs((-_killerKarma) * 0.25) + _playerKarmaAdj};

--- a/Sources/epoch_server/compile/epoch_player/EPOCH_server_deadPlayer.sqf
+++ b/Sources/epoch_server/compile/epoch_player/EPOCH_server_deadPlayer.sqf
@@ -13,7 +13,7 @@
     https://github.com/EpochModTeam/Epoch/tree/release/Sources/epoch_server/compile/epoch_player/EPOCH_server_deadPlayer.sqf
 */
 //[[[cog import generate_private_arrays ]]]
-private ["_bankBalance","_bankData","_cIndex","_current_crypto","_defaultVars","_playerName","_playerUID","_pos","_response","_triggerType","_vars","_killerUID","_deathType","_killerCommunityStats","_mIndex","_current_murders","_communityStats","_sIndex","_current_suicides","_dIndex","_current_deaths"];
+private ["_bankBalance","_bankData","_cIndex","_current_crypto","_defaultVars","_playerName","_playerUID","_pos","_response","_triggerType","_vars","_killerUID","_deathType","_killerCommunityStats","_mIndex","_current_murders","_communityStats","_sIndex","_current_suicides","_dIndex","_current_deaths","_playerKarmaAdj","_killerKarmaAdj","_kIndex","_playerCStats","_playerKarma","_playerIsNeutral","_playerIsBandit","_playerIsHero","_killerCStats","_killerKarma"];
 //[[[end]]]
 params ["_playerObj","_killer","_playerName",["_token","",[""]] ];
 
@@ -23,9 +23,21 @@ if !([_playerObj, _token] call EPOCH_server_getPToken) exitWith{};
 _playerUID = getPlayerUID _playerObj;
 _killerUID = getPlayerUID _killer;
 _pos = getposATL _playerObj;
+
+// find player's Karma status
+_kIndex = EPOCH_communityStats find "Karma";
+_playerCStats = _playerObj getVariable["COMMUNITY_STATS", EPOCH_defaultStatVars];
+_playerKarma = _playerCStats select _kIndex;
+_playerIsNeutral = (_playerKarma < 5000 && _playerKarma > -5000);
+_playerIsBandit = (_playerKarma <= -5000);
+_playerIsHero = (_playerKarma >= 5000);
+
+// default deathType is suicide
 _deathType = 666;
+_playerKarmaAdj = -2;
 
 if (_playerObj != _killer) then {
+	_playerKarmaAdj = -5;
 	if (random 1 <= EPOCH_antagonistChancePDeath) then {
 		_triggerType = 2;
 		if (surfaceIsWater _pos) then {
@@ -41,8 +53,36 @@ if (_playerObj != _killer) then {
 
 	['deathlog', format['%1 (%2) Killed By %3 (%4) with weapon %5 from %6m at %7', _playerName, _playerUID, name _killer, _killerUID, currentWeapon _killer, _playerObj distance _killer, _pos]] call EPOCH_fnc_server_hiveLog;
 	
+	// player karma changes
+	if(_playerIsNeutral)then{_playerKarmaAdj = abs((-_playerKarma) * 0.03)};
+	if(_playerIsBandit)then{_playerKarmaAdj = abs((-_playerKarma) * 0.055)};
+	if(_playerIsHero)then{_playerKarmaAdj = abs((-_playerKarma) * 0.025)};
+
 	if!(_killerUID isEqualTo "")then{
 		[_killer, "Murders", 1, true] call EPOCH_server_updatePlayerStats;
+		
+		// find killer's Karma status
+		_killerCStats = _killer getVariable["COMMUNITY_STATS", EPOCH_defaultStatVars];
+		_killerKarma = _killerCStats select _kIndex;
+		
+		// killer karma changes
+		_killerKarmaAdj = -5;
+		if(_killerKarma < 5000 && _killerKarma > -5000)then{
+			if(_playerIsNeutral)then{_killerKarmaAdj = abs((-_killerKarma) * 0.03) + _playerKarmaAdj};
+			if(_playerIsBandit)then{_killerKarmaAdj = abs((_killerKarma) * 0.05) + _playerKarmaAdj};
+			if(_playerIsHero)then{_killerKarmaAdj = abs((-_killerKarma) * 0.025) + _playerKarmaAdj};
+		};
+		if(_killerKarma <= -5000)then{
+			if(_playerIsNeutral)then{_killerKarmaAdj = abs((_killerKarma) * 0.05) + _playerKarmaAdj};
+			if(_playerIsBandit)then{_killerKarmaAdj = abs((-_killerKarma) * 0.15) + _playerKarmaAdj};
+			if(_playerIsHero)then{_killerKarmaAdj = abs((_killerKarma) * 0.15) + _playerKarmaAdj};
+		};
+		if(_killerKarma >= 5000)then{
+			if(_playerIsNeutral)then{_killerKarmaAdj = abs((-_killerKarma) * 0.10) + _playerKarmaAdj};
+			if(_playerIsBandit)then{_killerKarmaAdj = abs((_killerKarma) * 0.15) + _playerKarmaAdj};
+			if(_playerIsHero)then{_killerKarmaAdj = abs((-_killerKarma) * 0.25) + _playerKarmaAdj};
+		};
+		[_killer, "Karma", _killerKarmaAdj, true] call EPOCH_server_updatePlayerStats;
 	};
 	_deathType = 1;
 };
@@ -50,9 +90,11 @@ if (_playerObj != _killer) then {
 switch(_deathType)do{
 	case 666: {
 		[_playerObj, "Suicides", 1] call EPOCH_server_updatePlayerStats;
+		[_playerObj, "Karma", _playerKarmaAdj] call EPOCH_server_updatePlayerStats;
 	};
 	case 1: {
 		[_playerObj, "Deaths", 1] call EPOCH_server_updatePlayerStats;
+		[_playerObj, "Karma", _playerKarmaAdj] call EPOCH_server_updatePlayerStats;
 	};
 };
 _defaultVars = call EPOCH_defaultVars_SEPXVar;

--- a/Sources/epoch_server/compile/epoch_player/EPOCH_server_revivePlayer.sqf
+++ b/Sources/epoch_server/compile/epoch_player/EPOCH_server_revivePlayer.sqf
@@ -13,7 +13,7 @@
     https://github.com/EpochModTeam/Epoch/tree/release/Sources/epoch_server/compile/epoch_player/EPOCH_server_revivePlayer.sqf
 */
 //[[[cog import generate_private_arrays ]]]
-private ["_loadout","_CorpseCrypto","_PlayerCrypto","_attachments","_cIndex","_class","_currwh","_deleteprimary","_deletesecondary","_dir","_droppedPrimary","_droppedSecondary","_droppedWeapons","_equipped","_group","_location","_newPlyr","_playerGroup","_playerUID","_primaryWeapon","_secondaryWeapon","_token","_type","_vars","_wMags","_wMagsArray","_weapon","_wh"];
+private ["_loadout","_CorpseCrypto","_PlayerCrypto","_attachments","_cIndex","_class","_currwh","_deleteprimary","_deletesecondary","_dir","_droppedPrimary","_droppedSecondary","_droppedWeapons","_equipped","_group","_location","_newPlyr","_playerGroup","_playerUID","_primaryWeapon","_secondaryWeapon","_token","_type","_vars","_wMags","_wMagsArray","_weapon","_wh","_kIndex","_reviver","_reviverCStats","_reviverKarma","_reviverKarmaAdj"];
 //[[[end]]]
 params ["_player","_reviver",["_token","",[""]] ];
 
@@ -203,6 +203,14 @@ if (!local _player) then {
 
 				// send stat to reviver
 				[_reviver, "Revives", 1, true] call EPOCH_server_updatePlayerStats;
+				
+				// send karma stat to reviver
+				_kIndex = EPOCH_communityStats find "Karma";
+				_reviverCStats = _reviver getVariable["COMMUNITY_STATS", EPOCH_defaultStatVars];
+				_reviverKarma = _reviverCStats select _kIndex;
+				_reviverKarmaAdj = 5;
+				if(_reviverKarma < 0)then{_reviverKarmaAdj = -5};
+				[_reviver, "Karma", _reviverKarmaAdj, true] call EPOCH_server_updatePlayerStats;
 			};
 		};
 	};

--- a/Sources/epoch_server/compile/epoch_server/EPOCH_server_traderKilled.sqf
+++ b/Sources/epoch_server/compile/epoch_server/EPOCH_server_traderKilled.sqf
@@ -13,7 +13,7 @@
     https://github.com/EpochModTeam/Epoch/tree/release/Sources/epoch_server/compile/epoch_server/EPOCH_server_traderKilled.sqf
 */
 //[[[cog import generate_private_arrays ]]]
-private ["_marker","_objHiveKey","_slot"];
+private ["_marker","_objHiveKey","_slot","_playerCStats","_playerKarma","_playerKarmaAdj","_kIndex"];
 //[[[end]]]
 params ["_trader","_player"];
 if (!isNull _trader) then {
@@ -28,4 +28,11 @@ if (!isNull _trader) then {
 		_objHiveKey = format ["%1:%2", (call EPOCH_fn_InstanceID), _slot];
 		["AI", _objHiveKey] call EPOCH_fnc_server_hiveDEL;
 	};
+	// send karma stat to seller
+	_kIndex = EPOCH_communityStats find "Karma";
+	_playerCStats = _player getVariable["COMMUNITY_STATS", EPOCH_defaultStatVars];
+	_playerKarma = _playerCStats select _kIndex;
+	_playerKarmaAdj = -5;
+	if(_playerKarma < 0)then{_playerKarmaAdj = 5};
+	[_player, "Karma", _playerKarmaAdj, true] call EPOCH_server_updatePlayerStats;
 };

--- a/Sources/epoch_server/compile/epoch_trading/EPOCH_server_makeNPCTrade.sqf
+++ b/Sources/epoch_server/compile/epoch_trading/EPOCH_server_makeNPCTrade.sqf
@@ -13,7 +13,7 @@
     https://github.com/EpochModTeam/Epoch/tree/release/Sources/epoch_server/compile/epoch_trading/EPOCH_server_makeNPCTrade.sqf
 */
 //[[[cog import generate_private_arrays ]]]
-private ["_MaxBankDebit","_SkipOut","_VAL","_aiItems","_bankBalance","_bankData","_cIndex","_config","_currQty","_current_crypto","_current_cryptoRaw","_errorMsg","_final_location","_foundSmoke","_group","_helipad","_helipads","_item","_itemClasses","_itemQty","_itemQtys","_itemTax","_itemWorth","_itemsIn","_itemsOut","_lockOwner","_makeTradeIn","_message","_nearByHolder","_objHiveKey","_objOwner","_playerCryptoLimit","_playerGroup","_playerNetID","_playerUID","_position","_qtyIndex","_response","_return","_returnIn","_returnOut","_road","_serverSettingsConfig","_slot","_smoke","_tax","_tmpposition","_tradeIn","_tradeOut","_tradeQtyTotal","_tradeTotal","_vars","_vehHiveKey","_vehObj","_vehSlot","_vehicle","_vehicleBought","_vehicleSold","_vehicles","_vehslot","_wH","_wHPos","_wp"];
+private ["_MaxBankDebit","_SkipOut","_VAL","_aiItems","_bankBalance","_bankData","_cIndex","_config","_currQty","_current_crypto","_current_cryptoRaw","_errorMsg","_final_location","_foundSmoke","_group","_helipad","_helipads","_item","_itemClasses","_itemQty","_itemQtys","_itemTax","_itemWorth","_itemsIn","_itemsOut","_lockOwner","_makeTradeIn","_message","_nearByHolder","_objHiveKey","_objOwner","_playerCryptoLimit","_playerGroup","_playerNetID","_playerUID","_position","_qtyIndex","_response","_return","_returnIn","_returnOut","_road","_serverSettingsConfig","_slot","_smoke","_tax","_tmpposition","_tradeIn","_tradeOut","_tradeQtyTotal","_tradeTotal","_vars","_vehHiveKey","_vehObj","_vehSlot","_vehicle","_vehicleBought","_vehicleSold","_vehicles","_vehslot","_wH","_wHPos","_wp","_kIndex","_playerCStats","_playerKarma","_playerKarmaAdj"];
 //[[[end]]]
 params ["_trader","_itemsIn","_itemsOut","_player",["_token","",[""]] ];
 
@@ -118,6 +118,13 @@ if (_slot != -1) then {
 					_current_crypto = _current_crypto + _itemWorth;
 					_tradeQtyTotal = _tradeQtyTotal + _itemQty;
 				};
+				// send karma stat to seller
+				_kIndex = EPOCH_communityStats find "Karma";
+				_playerCStats = _player getVariable["COMMUNITY_STATS", EPOCH_defaultStatVars];
+				_playerKarma = _playerCStats select _kIndex;
+				_playerKarmaAdj = 1;
+				if(_playerKarma > 0)then{_playerKarmaAdj = -1};
+				[_player, "Karma", _playerKarmaAdj, true] call EPOCH_server_updatePlayerStats;
 			};
 		};
 	} forEach _itemsIn;
@@ -294,6 +301,13 @@ if (_slot != -1) then {
 								_current_crypto = _current_crypto - _itemWorth;
 								_tradeQtyTotal = _tradeQtyTotal + _itemQty;
 							};
+							// send karma stat to buyer
+							_kIndex = EPOCH_communityStats find "Karma";
+							_playerCStats = _player getVariable["COMMUNITY_STATS", EPOCH_defaultStatVars];
+							_playerKarma = _playerCStats select _kIndex;
+							_playerKarmaAdj = 1;
+							if(_playerKarma > 0)then{_playerKarmaAdj = -1};
+							[_player, "Karma", _playerKarmaAdj, true] call EPOCH_server_updatePlayerStats;
 						};
 					};
 				};

--- a/Sources/epoch_server/compile/epoch_trading/EPOCH_server_makeNPCTrade.sqf
+++ b/Sources/epoch_server/compile/epoch_trading/EPOCH_server_makeNPCTrade.sqf
@@ -123,7 +123,7 @@ if (_slot != -1) then {
 				_playerCStats = _player getVariable["COMMUNITY_STATS", EPOCH_defaultStatVars];
 				_playerKarma = _playerCStats select _kIndex;
 				_playerKarmaAdj = 1;
-				if(_playerKarma > 0)then{_playerKarmaAdj = -1};
+				if(_playerKarma < 0)then{_playerKarmaAdj = -1};
 				[_player, "Karma", _playerKarmaAdj, true] call EPOCH_server_updatePlayerStats;
 			};
 		};
@@ -306,7 +306,7 @@ if (_slot != -1) then {
 							_playerCStats = _player getVariable["COMMUNITY_STATS", EPOCH_defaultStatVars];
 							_playerKarma = _playerCStats select _kIndex;
 							_playerKarmaAdj = 1;
-							if(_playerKarma > 0)then{_playerKarmaAdj = -1};
+							if(_playerKarma < 0)then{_playerKarmaAdj = -1};
 							[_player, "Karma", _playerKarmaAdj, true] call EPOCH_server_updatePlayerStats;
 						};
 					};


### PR DESCRIPTION
Move Karma from Vars to Community Stats
Add Karma stat changes for various current Epoch features, such as PvP, revive, trade sales and purchases, deaths, suicides and even trader killings.

Added a low and high levels config. its WIP but will handle the current system for testing and prep for expansion.