### PR TITLE
New items for crafting and building

### DIFF
--- a/Sources/epoch_config/Configs/CfgBaseBuilding.hpp
+++ b/Sources/epoch_config/Configs/CfgBaseBuilding.hpp
@@ -724,6 +724,253 @@ class CfgBaseBuilding
         energyCost = 0.1;
     };
     class Jack_SIM_EPOCH : Jack_EPOCH {};
+    class BurnBarrel_EPOCH : Default
+    {
+        removeParts[] = {{"KitBurnBarrel",1}};
+        GhostPreview = "BurnBarrel_Ghost_EPOCH";
+        staticClass = "BurnBarrel_EPOCH";
+        simulClass = "BurnBarrel_SIM_EPOCH";
+    };
+    class BurnBarrel_SIM_EPOCH : BurnBarrel_EPOCH
+    {
+        removeParts[] = {};
+    };
+    class BurnBarrel_Ghost_EPOCH : BurnBarrel_SIM_EPOCH {};
+    class LightPole_EPOCH : Default
+    {
+        removeParts[] = {{"KitLightPole",1}};
+        GhostPreview = "LightPole_Ghost_EPOCH";
+        staticClass = "LightPole_EPOCH";
+        simulClass = "LightPole_SIM_EPOCH";
+    };
+    class LightPole_SIM_EPOCH : LightPole_EPOCH
+    {
+        removeParts[] = {};
+    };
+    class LightPole_Ghost_EPOCH : LightPole_SIM_EPOCH {};
+    class SmallForestCamoNet_EPOCH : Default
+    {
+        removeParts[] = {{"KitSmallForestCamoNet",1}};
+        GhostPreview = "SmallForestCamoNet_Ghost_EPOCH";
+        staticClass = "SmallForestCamoNet_EPOCH";
+        simulClass = "SmallForestCamoNet_SIM_EPOCH";
+    };
+    class SmallForestCamoNet_SIM_EPOCH : SmallForestCamoNet_EPOCH
+    {
+        removeParts[] = {};
+    };
+    class SmallForestCamoNet_Ghost_EPOCH : SmallForestCamoNet_SIM_EPOCH {};
+    class SmallDesertCamoNet_EPOCH : Default
+    {
+        removeParts[] = {{"KitSmallDesertCamoNet",1}};
+        GhostPreview = "SmallDesertCamoNet_Ghost_EPOCH";
+        staticClass = "SmallDesertCamoNet_EPOCH";
+        simulClass = "SmallDesertCamoNet_SIM_EPOCH";
+    };
+    class SmallDesertCamoNet_SIM_EPOCH : SmallDesertCamoNet_EPOCH
+    {
+        removeParts[] = {};
+    };
+    class SmallDesertCamoNet_Ghost_EPOCH : SmallDesertCamoNet_SIM_EPOCH {};
+    class LargeForestCamoNet_EPOCH : Default
+    {
+        removeParts[] = {{"KitLargeForestCamoNet",1}};
+        GhostPreview = "LargeForestCamoNet_Ghost_EPOCH";
+        staticClass = "LargeForestCamoNet_EPOCH";
+        simulClass = "LargeForestCamoNet_SIM_EPOCH";
+    };
+    class LargeForestCamoNet_SIM_EPOCH : LargeForestCamoNet_EPOCH
+    {
+        removeParts[] = {};
+    };
+    class LargeForestCamoNet_Ghost_EPOCH : LargeForestCamoNet_SIM_EPOCH {};
+    class LargeDesertCamoNet_EPOCH : Default
+    {
+        removeParts[] = {{"KitLargeDesertCamoNet",1}};
+        GhostPreview = "LargeDesertCamoNet_Ghost_EPOCH";
+        staticClass = "LargeDesertCamoNet_EPOCH";
+        simulClass = "LargeDesertCamoNet_SIM_EPOCH";
+    };
+    class LargeDesertCamoNet_SIM_EPOCH : LargeDesertCamoNet_EPOCH
+    {
+        removeParts[] = {};
+    };
+    class LargeDesertCamoNet_Ghost_EPOCH : LargeDesertCamoNet_SIM_EPOCH {};
+    class FirePlace_02_EPOCH : Default
+    {
+        removeParts[] = {{"KitFirePlace_02",1}};
+        GhostPreview = "FirePlace_02_Ghost_EPOCH";
+        staticClass = "FirePlace_02_EPOCH";
+        simulClass = "FirePlace_02_SIM_EPOCH";
+    };
+    class FirePlace_02_SIM_EPOCH : FirePlace_02_EPOCH
+    {
+        removeParts[] = {};
+    };
+    class FirePlace_02_Ghost_EPOCH : FirePlace_02_SIM_EPOCH {};
+    class FieldToilet_EPOCH : Default
+    {
+        removeParts[] = {{"KitFieldToilet",1}};
+        GhostPreview = "FieldToilet_Ghost_EPOCH";
+        staticClass = "FieldToilet_EPOCH";
+        simulClass = "FieldToilet_SIM_EPOCH";
+    };
+    class FieldToilet_SIM_EPOCH : FieldToilet_EPOCH
+    {
+        removeParts[] = {};
+    };
+    class FieldToilet_Ghost_EPOCH : FieldToilet_SIM_EPOCH {};
+    class Scaffolding_EPOCH : Default
+    {
+        removeParts[] = {{"KitScaffolding",1}};
+        GhostPreview = "Scaffolding_Ghost_EPOCH";
+        staticClass = "Scaffolding_EPOCH";
+        simulClass = "Scaffolding_SIM_EPOCH";
+    };
+    class Scaffolding_SIM_EPOCH : Scaffolding_EPOCH
+    {
+        removeParts[] = {};
+    };
+    class Scaffolding_Ghost_EPOCH : Scaffolding_SIM_EPOCH {};
+    class Sink_EPOCH : Default
+    {
+        removeParts[] = {{"KitSink",1}};
+        GhostPreview = "Sink_Ghost_EPOCH";
+        staticClass = "Sink_EPOCH";
+        simulClass = "Sink_SIM_EPOCH";
+    };
+    class Sink_SIM_EPOCH : Sink_EPOCH
+    {
+        removeParts[] = {};
+    };
+    class Sink_Ghost_EPOCH : Sink_SIM_EPOCH {};
+    class PortableLight_Single_EPOCH : Default
+    {
+        removeParts[] = {{"KitPortableLight_Single",1}};
+        GhostPreview = "PortableLight_Single_Ghost_EPOCH";
+        staticClass = "PortableLight_Single_EPOCH";
+        simulClass = "PortableLight_Single_SIM_EPOCH";
+    };
+    class PortableLight_Single_SIM_EPOCH : PortableLight_Single_EPOCH
+    {
+        removeParts[] = {};
+    };
+    class PortableLight_Single_Ghost_EPOCH : PortableLight_Single_SIM_EPOCH {};
+    class PortableLight_Double_EPOCH : Default
+    {
+        removeParts[] = {{"KitPortableLight_Double",1}};
+        GhostPreview = "PortableLight_Double_Ghost_EPOCH";
+        staticClass = "PortableLight_Double_EPOCH";
+        simulClass = "PortableLight_Double_SIM_EPOCH";
+    };
+    class PortableLight_Double_SIM_EPOCH : PortableLight_Double_EPOCH
+    {
+        removeParts[] = {};
+    };
+    class PortableLight_Double_Ghost_EPOCH : PortableLight_Double_SIM_EPOCH {};
+    class WatchTower_EPOCH : Default
+    {
+        removeParts[] = {{"KitWatchTower",1}};
+        GhostPreview = "WatchTower_Ghost_EPOCH";
+        staticClass = "WatchTower_EPOCH";
+        simulClass = "WatchTower_SIM_EPOCH";
+    };
+    class WatchTower_SIM_EPOCH : WatchTower_EPOCH
+    {
+        removeParts[] = {};
+    };
+    class WatchTower_Ghost_EPOCH : WatchTower_SIM_EPOCH {};
+    class SunShade_EPOCH : Default
+    {
+        removeParts[] = {{"KitSunShade",1}};
+        GhostPreview = "SunShade_Ghost_EPOCH";
+        staticClass = "SunShade_EPOCH";
+        simulClass = "SunShade_SIM_EPOCH";
+    };
+    class SunShade_SIM_EPOCH : SunShade_EPOCH
+    {
+        removeParts[] = {};
+    };
+    class SunShade_Ghost_EPOCH : SunShade_SIM_EPOCH {};
+    class FuelPump_EPOCH : Default
+    {
+        removeParts[] = {{"KitFuelPump",1}};
+        GhostPreview = "FuelPump_Ghost_EPOCH";
+        staticClass = "FuelPump_EPOCH";
+        simulClass = "FuelPump_SIM_EPOCH";
+    };
+    class FuelPump_SIM_EPOCH : FuelPump_EPOCH
+    {
+        removeParts[] = {};
+    };
+    class FuelPump_Ghost_EPOCH : FuelPump_SIM_EPOCH {};
+    class BagBunker_EPOCH : Default
+    {
+        removeParts[] = {{"KitBagBunker",1}};
+        GhostPreview = "BagBunker_Ghost_EPOCH";
+        staticClass = "BagBunker_EPOCH";
+        simulClass = "BagBunker_SIM_EPOCH";
+    };
+    class BagBunker_SIM_EPOCH : BagBunker_EPOCH
+    {
+        removeParts[] = {};
+    };
+    class BagBunker_Ghost_EPOCH : BagBunker_SIM_EPOCH {};
+    class SandbagWall_EPOCH : Default
+    {
+        removeParts[] = {{"KitSandbagWall",1}};
+        GhostPreview = "SandbagWall_Ghost_EPOCH";
+        staticClass = "SandbagWall_EPOCH";
+        simulClass = "SandbagWall_SIM_EPOCH";
+    };
+    class SandbagWall_SIM_EPOCH : SandbagWall_EPOCH
+    {
+        removeParts[] = {};
+    };
+    class SandbagWall_Ghost_EPOCH : SandbagWall_SIM_EPOCH {};
+    class SandbagWallLong_EPOCH : Default
+    {
+        removeParts[] = {{"KitSandbagWallLong",1}};
+        GhostPreview = "SandbagWallLong_Ghost_EPOCH";
+        staticClass = "SandbagWallLong_EPOCH";
+        simulClass = "SandbagWallLong_SIM_EPOCH";
+    };
+    class SandbagWallLong_SIM_EPOCH : SandbagWallLong_EPOCH
+    {
+        removeParts[] = {};
+    };
+    class SandbagWallLong_Ghost_EPOCH : SandbagWallLong_SIM_EPOCH {};
+    class BarGate_EPOCH : Default
+    {
+        removeParts[] = {{"KitBarGate",1}};
+        GhostPreview = "BarGate_Ghost_EPOCH";
+        staticClass = "BarGate_EPOCH";
+        simulClass = "BarGate_SIM_EPOCH";
+    };
+    class BarGate_SIM_EPOCH : BarGate_EPOCH
+    {
+        removeParts[] = {};
+    };
+    class BarGate_Ghost_EPOCH : BarGate_SIM_EPOCH {};
+    class WaterPump_EPOCH : Default
+    {
+        removeParts[] = {{"KitWaterPump",1}};
+        GhostPreview = "WaterPump_Ghost_EPOCH";
+        staticClass = "WaterPump_EPOCH";
+        simulClass = "WaterPump_SIM_EPOCH";
+    };
+    class WaterPump_SIM_EPOCH : WaterPump_EPOCH
+    {
+        removeParts[] = {};
+    };
+    class WaterPump_Ghost_EPOCH : WaterPump_SIM_EPOCH {};
+    class IG_Box_s : Default
+    {
+        removeParts[] = {{"Kit_IG_Box_s",1}};
+        GhostPreview = "IG_Box_s";
+        staticClass = "IG_Box_s";
+        simulClass = "IG_Box_s_SIM";
+    };
 };
 
 /*[[[end]]]*/

--- a/Sources/epoch_config/Configs/CfgItemInteractions.hpp
+++ b/Sources/epoch_config/Configs/CfgItemInteractions.hpp
@@ -473,6 +473,86 @@ class CfgItemInteractions
 		buildClass = "Garden_EPOCH";
 		isStorage = 1;
 	};
+    class KitBurnBarrel : Item_Build_base
+    {
+        buildClass = "BurnBarrel_EPOCH";
+    };
+    class KitLightPole : Item_Build_base
+    {
+        buildClass = "LightPole_EPOCH";
+    };
+    class KitSmallForestCamoNet : Item_Build_base
+    {
+        buildClass = "SmallForestCamoNet_EPOCH";
+    };
+    class KitSmallDesertCamoNet : Item_Build_base
+    {
+        buildClass = "SmallDesertCamoNet_EPOCH";
+    };
+    class KitLargeForestCamoNet : Item_Build_base
+    {
+        buildClass = "LargeForestCamoNet_EPOCH";
+    };
+    class KitLargeDesertCamoNet : Item_Build_base
+    {
+        buildClass = "LargeDesertCamoNet_EPOCH";
+    };
+    class KitFirePlace_02 : Item_Build_base
+    {
+        buildClass = "FirePlace_02_EPOCH";
+    };
+    class KitFieldToilet : Item_Build_base
+    {
+        buildClass = "FieldToilet_EPOCH";
+    };
+    class KitScaffolding : Item_Build_base
+    {
+        buildClass = "Scaffolding_EPOCH";
+    };
+    class KitSink : Item_Build_base
+    {
+        buildClass = "Sink_EPOCH";
+    };
+    class KitPortableLight_Single : Item_Build_base
+    {
+        buildClass = "PortableLight_Single_EPOCH";
+    };
+    class KitPortableLight_Double : Item_Build_base
+    {
+        buildClass = "PortableLight_Double_EPOCH";
+    };
+    class KitWatchTower : Item_Build_base
+    {
+        buildClass = "WatchTower_EPOCH";
+    };
+    class KitSunShade : Item_Build_base
+    {
+        buildClass = "SunShade_EPOCH";
+    };
+    class KitFuelPump : Item_Build_base
+    {
+        buildClass = "FuelPump_EPOCH";
+    };
+    class KitBagBunker : Item_Build_base
+    {
+        buildClass = "BagBunker_EPOCH";
+    };
+    class KitSandBagWall : Item_Build_base
+    {
+        buildClass = "SandBagWall_EPOCH";
+    };
+    class KitSandBagWallLong : Item_Build_base
+    {
+        buildClass = "SandBagWallLong_EPOCH";
+    };
+    class KitBarGate : Item_Build_base
+    {
+        buildClass = "BarGate_EPOCH";
+    };
+    class KitWaterPump : Item_Build_base
+    {
+        buildClass = "WaterPump_EPOCH";
+    };
     class PaintCanBase : Default
     {
         interactAction = 12;

--- a/Sources/epoch_config/Configs/cfgCrafting.hpp
+++ b/Sources/epoch_config/Configs/cfgCrafting.hpp
@@ -148,7 +148,7 @@ class CfgCrafting
     };
     class CircuitParts : Part
     {
-        usedIn[] = {"EnergyPack","EnergyPackLg","KitPlotPole","ItemBattery","KitSolarGen","KitVehicleUpgradeI_200_EPOCH","KitVehicleUpgradeIV_200_EPOCH","BarrelBomb_EPOCH_Remote_Mag","BarrelBomb2_EPOCH_Remote_Mag"};
+        usedIn[] = {"EnergyPack","EnergyPackLg","KitPlotPole","ItemBattery","KitSolarGen","KitVehicleUpgradeI_200_EPOCH","KitVehicleUpgradeIV_200_EPOCH","BarrelBomb_EPOCH_Remote_Mag","BarrelBomb2_EPOCH_Remote_Mag","KitPortableLight_Single","KitPortableLight_Double"};
         previewPosition[] = {0.791044,1,0.256956};
         previewScale = 2;
         previewVector = 2.3;
@@ -257,7 +257,7 @@ class CfgCrafting
     };
     class ItemStick : Item
     {
-        usedIn[] = {"WoodClub","MeleeMaul","CrudeHatchet","KitFirePlace","KitSpikeTrap","KitMetalTrap","MeleeRod"};
+        usedIn[] = {"WoodClub","MeleeMaul","CrudeHatchet","KitFirePlace","KitSpikeTrap","KitMetalTrap","MeleeRod","KitSunShade"};
         recipe[] = {{"WoodLog_EPOCH",1}};
         previewPosition[] = {0.8,1,0.25};
         previewScale = 0.4;
@@ -279,7 +279,7 @@ class CfgCrafting
     };
     class ItemRope : Item
     {
-        usedIn[] = {"WoodClub","MeleeMaul","CrudeHatchet","MeleeRod"};
+        usedIn[] = {"WoodClub","MeleeMaul","CrudeHatchet","MeleeRod","KitSunShade","KitScaffolding"};
         nearby[] = {{"Workbench","","workbench",{1,{"WorkBench_EPOCH"}},3,1,0,1}};
         recipe[] = {{"ItemKiloHemp",1}};
         previewPosition[] = {0.8,1,0.35};
@@ -287,7 +287,7 @@ class CfgCrafting
     };
     class ItemBurlap : Item
     {
-        usedIn[] = {"KitHesco3","KitVehicleUpgradeIII_200_EPOCH"};
+        usedIn[] = {"KitHesco3","KitVehicleUpgradeIII_200_EPOCH","KitSandbagWall","KitSandbagWallLong","KitBagBunker"};
         nearby[] = {{"Workbench","","workbench",{1,{"WorkBench_EPOCH"}},3,1,0,1}};
         recipe[] = {{"ItemKiloHemp",2}};
         previewPosition[] = {0.8,1,0.38};
@@ -316,13 +316,13 @@ class CfgCrafting
     };
     class WoodLog_EPOCH : Part
     {
-        usedIn[] = {"PartPlankPack","ItemStick","ItemPlywoodPack"};
+        usedIn[] = {"PartPlankPack","ItemStick","ItemPlywoodPack","KitBurnBarrel"};
         previewPosition[] = {0.800064,1,0.25};
         previewScale = 0.3;
     };
     class MortarBucket : Item
     {
-        usedIn[] = {"KitFoundation","KitCinderWall","KitHesco3","KitCinderFloor","KitCinderTower"};
+        usedIn[] = {"KitFoundation","KitCinderWall","KitHesco3","KitCinderFloor","KitCinderTower","KitSandbagWall","KitSandbagWallLong","KitBagBunker","KitWaterPump"};
         nearby[] = {{"Fire","","fire",{1,{"ALL"}},3,1,1,0},{"Workbench","","workbench",{1,{"WorkBench_EPOCH"}},3,1,0,1}};
         recipe[] = {{"ItemRock",12},{"water_epoch",2}};
         previewPosition[] = {0.799442,1,0.426761};
@@ -340,7 +340,7 @@ class CfgCrafting
     };
     class ItemCorrugated : Item
     {
-        usedIn[] = {"KitShelf","ItemCorrugatedLg","VehicleRepairLg","EngineParts"};
+        usedIn[] = {"KitShelf","ItemCorrugatedLg","VehicleRepairLg","EngineParts","ItemSink","ItemFieldToilet","ItemWaterPump","ItemLightPole"};
         nearby[] = {{"Fire","","fire",{1,{"ALL"}},3,1,1,0}};
         recipe[] = {{"ItemScraps",2}};
         previewPosition[] = {0.791088,1,0.300004};
@@ -349,7 +349,7 @@ class CfgCrafting
     };
     class CinderBlocks : Part
     {
-        usedIn[] = {"KitCinderWall","KitCinderFloor","KitCinderTower"};
+        usedIn[] = {"KitCinderWall","KitCinderFloor","KitCinderTower","KitBarGate","KitWaterPump"};
         previewPosition[] = {0.801866,1,0.35};
         previewScale = 0.2;
     };
@@ -361,7 +361,7 @@ class CfgCrafting
     };
     class jerrycan_epoch : Part
     {
-        usedIn[] = {"CSGAS","KitVehicleUpgradeIV_200_EPOCH","BarrelBomb_EPOCH_Remote_Mag","BarrelBomb2_EPOCH_Remote_Mag"};
+        usedIn[] = {"CSGAS","KitVehicleUpgradeIV_200_EPOCH","BarrelBomb_EPOCH_Remote_Mag","BarrelBomb2_EPOCH_Remote_Mag","KitBurnBarrel"};
         previewPosition[] = {0.802443,1,0.254301};
         previewScale = 0.6;
         previewVector = 4.9;
@@ -728,7 +728,7 @@ class CfgCrafting
     };
     class ItemCorrugatedLg : Item
     {
-        usedIn[] = {"KitPlotPole","KitTankTrap","KitHesco3","KitSolarGen","ItemRotor","EngineBlock","KitMetalFloor","KitMetalTower"};
+        usedIn[] = {"KitPlotPole","KitTankTrap","KitHesco3","KitSolarGen","ItemRotor","EngineBlock","KitMetalFloor","KitMetalTower","KitFieldToilet","KitSink","KitPortableLight_Single","KitPortableLight_Double"};
         recipe[] = {{"ItemCorrugated",3}};
         nearby[] = {{"Workbench","","workbench",{1,{"WorkBench_EPOCH"}},3,1,0,1}};
         previewPosition[] = {0.797491,1,0.32899};
@@ -737,7 +737,7 @@ class CfgCrafting
     };
     class PartPlankPack : Item
     {
-        usedIn[] = {"KitStudWall","KitWoodFloor","KitWoodFoundation","KitWoodStairs","KitWoodRamp","KitWoodLadder","KitWoodTower","KitTiPi","KitWorkbench","KitSpikeTrap","KitMetalTrap","KitWoodQuarterFloor"};
+        usedIn[] = {"KitStudWall","KitWoodFloor","KitWoodFoundation","KitWoodStairs","KitWoodRamp","KitWoodLadder","KitWoodTower","KitTiPi","KitWorkbench","KitSpikeTrap","KitMetalTrap","KitWoodQuarterFloor","KitBarGate","KitBagBunker","KitWatchTower","KitLightPole","KitScaffolding"};
         recipe[] = {{"WoodLog_EPOCH",2}};
         previewPosition[] = {0.797837,1,0.288258};
         previewScale = 0.2;
@@ -790,7 +790,7 @@ class CfgCrafting
     };
     class KitWoodFloor : Kit
     {
-        usedIn[] = {"KitWoodTower"};
+        usedIn[] = {"KitWoodTower","KitBagBunker"};
         recipe[] = {{"PartPlankPack",8}};
         nearby[] = {{"Workbench","","workbench",{1,{"WorkBench_EPOCH"}},3,1,0,1}};
         model = "\x\addons\a3_epoch_assets\models\Wooden_Floor.p3d";
@@ -1247,6 +1247,20 @@ class CfgCrafting
         previewScale = 0.2;
         previewVector = 0.5;
     };
+    class ItemCanvas : Part
+    {
+        usedIn[] = {"KitTentA","KitTentDome","KitSunShade","KitWatchTower","KitScaffolding"};
+        previewPosition[] = {0.802443,1,0.254301};
+        previewScale = 0.8;
+        previewVector = 4.9;
+    };
+    class ItemBulb : Part
+    {
+        usedIn[] = {"KitLightPole","KitPortableLight_Single","KitPortableLight_Double"};
+        previewPosition[] = {0.802443,1,0.254301};
+        previewScale = 0.95;
+        previewVector = 4.9;
+    };
 
 	class BarrelBomb_EPOCH_Remote_Mag : Kit
     {
@@ -1264,18 +1278,11 @@ class CfgCrafting
 	};
     class ItemBarrelE : Part
     {
-        usedIn[] = {"BarrelBomb_EPOCH_Remote_Mag","BarrelBomb2_EPOCH_Remote_Mag"};
+        usedIn[] = {"BarrelBomb_EPOCH_Remote_Mag","BarrelBomb2_EPOCH_Remote_Mag","KitBurnBarrel"};
 		previewPosition[] = {0.79545,1,0.234395};
 		previewScale = 0.2;
 		previewVector = 0.1;
     };
-	class ItemCanvas : Part
-	{
-		usedIn[] = {"KitTentA","KitTentDome"};
-		previewPosition[] = {0.802374,1,0.26};
-		previewScale = 0.45;
-		previewVector = 3.3;
-	};
 	class ItemSeedBag : Part
 	{
 		usedIn[] = {};
@@ -1344,6 +1351,131 @@ class CfgCrafting
 		previewScale = 2.5;
 		displayName = "Clean Water in a canteen";
 	};
+    class lighter_epoch : Part
+    {
+        usedIn[] = {"KitBurnBarrel"};
+		previewPosition[] = {0.79545,1,0.234395};
+        previewScale = 2.5;
+		previewVector = 0.5;
+    };
+    class KitBurnBarrel : Kit
+    {
+        recipe[] = {{"ItemBarrelE",1},{"jerrycan_epoch",1},{"WoodLog_EPOCH",3},{"lighter_epoch",1}};
+		model = "\A3\Structures_F\Items\Vessels\MetalBarrel_empty_F.p3d";
+		previewPosition[] = {0.79545,1,0.234395};
+		previewScale = 0.30;
+    };
+    class KitLightPole : Kit
+    {
+        recipe[] = {{"ItemBulb",1},{"ItemCables",1},{"ItemBattery",1},{"ItemCorrugated",1},{"PartPlankPack",4}};
+        nearby[] = {{"Workbench","","workbench",{1,{"WorkBench_EPOCH"}},3,1,0,1}};
+		model = "\A3\Structures_F\Civ\Lamps\LampShabby_F.p3d";
+        previewPosition[] = {0.796787,1,0.27};
+        previewScale = 0.040;
+        previewVector = 0;
+    };
+    class KitFieldToilet : Kit
+    {
+        recipe[] = {{"ItemCorrugatedLg",2},{"ItemCorrugated",2}};
+        nearby[] = {{"Workbench","","workbench",{1,{"WorkBench_EPOCH"}},3,1,0,1}};
+		model = "\A3\Structures_F\Civ\Camping\FieldToilet_F.p3d";
+        previewPosition[] = {0.796787,1,0.27};
+        previewScale = 0.1;
+        previewVector = 0;
+    };
+    class KitScaffolding : Kit
+    {
+        recipe[] = {{"ItemPipe",16},{"PartPlankPack",2},{"ItemRope",12},{"ItemCanvas",4}};
+        nearby[] = {{"Workbench","","workbench",{1,{"WorkBench_EPOCH"}},3,1,0,1}};
+		model = "\A3\Structures_F\Civ\Constructions\Scaffolding_F.p3d";
+        previewPosition[] = {0.82,1,0.27};
+        previewScale = 0.021;
+        previewVector = 0;
+    };
+    class KitSink : Kit
+    {
+        recipe[] = {{"ItemCorrugatedLg",2},{"ItemPipe",1},{"ItemCorrugated",2}};
+        nearby[] = {{"Workbench","","workbench",{1,{"WorkBench_EPOCH"}},3,1,0,1}};
+		model = "\A3\Structures_F\Civ\Accessories\Sink_F.p3d";
+        previewPosition[] = {0.796787,1,0.27};
+        previewScale = 0.1;
+        previewVector = 0;
+    };
+    class KitPortableLight_Single : Kit
+    {
+        recipe[] = {{"ItemBulb",1},{"ItemCables",1},{"ItemBattery",1},{"ItemCorrugatedLg",1},{"CircuitParts",1}};
+        nearby[] = {{"Workbench","","workbench",{1,{"WorkBench_EPOCH"}},3,1,0,1}};
+		model = "\A3\Structures_F_EPA\Civ\Constructions\PortableLight_single_F.p3d";
+        previewPosition[] = {0.796787,1,0.27};
+        previewScale = 0.1;
+        previewVector = 0;
+    };
+    class KitPortableLight_Double : Kit
+    {
+        recipe[] = {{"ItemBulb",2},{"ItemCables",2},{"ItemBattery",1},{"ItemCorrugatedLg",1},{"CircuitParts",2}};
+        nearby[] = {{"Workbench","","workbench",{1,{"WorkBench_EPOCH"}},3,1,0,1}};
+		model = "\A3\Structures_F_EPA\Civ\Constructions\PortableLight_double_F.p3d";
+        previewPosition[] = {0.796787,1,0.27};
+        previewScale = 0.1;
+        previewVector = 0;
+    };
+    class KitWatchTower : Kit
+    {
+        recipe[] = {{"PartPlankPack",8},{"ItemRope",4},{"ItemCanvas",2}};
+		model = "\A3\Structures_F_EPC\Civ\Accessories\LifeguardTower_01_F.p3d";
+        previewPosition[] = {0.796787,1,0.27};
+        previewScale = 0.040;
+        previewVector = 0;
+    };
+    class KitSunShade : Kit
+    {
+        recipe[] = {{"ItemCanvas",1},{"ItemPipe",1},{"ItemRope",1},{"ItemStick",4}};
+        nearby[] = {{"Workbench","","workbench",{1,{"WorkBench_EPOCH"}},3,1,0,1}};
+		model = "\A3\Structures_F_EPC\Civ\Camping\Sunshade_03_F.p3d";
+        previewPosition[] = {0.796787,1,0.22};
+        previewScale = 0.06;
+        previewVector = 0;
+    };
+    class KitSandbagWall : Kit
+    {
+        recipe[] = {{"ItemBurlap",2},{"MortarBucket",2}};
+		model = "A3\Structures_F\Mil\BagFence\BagFence_Short_F.p3d";
+        previewPosition[] = {0.796787,1,0.22};
+        previewScale = 0.15;
+        previewVector = 0;
+    };
+    class KitSandbagWallLong : Kit
+    {
+        recipe[] = {{"ItemBurlap",4},{"MortarBucket",4}};
+		model = "A3\Structures_F\Mil\BagFence\BagFence_Long_F.p3d";
+        previewPosition[] = {0.796787,1,0.22};
+        previewScale = 0.1;
+        previewVector = 0;
+    };
+    class KitBagBunker : Kit
+    {
+        recipe[] = {{"ItemBurlap",8},{"MortarBucket",8},{"KitWoodFloor",1},{"PartPlankPack",2}};
+		model = "\A3\Structures_F\Mil\BagBunker\BagBunker_Small_F.p3d";
+        previewPosition[] = {0.81,1,0.22};
+        previewScale = 0.055;
+        previewVector = 0;
+    };
+    class KitBarGate : Kit
+    {
+        recipe[] = {{"PartPlankPack",6},{"CinderBlocks",1}};
+		model = "\A3\Structures_F\Walls\BarGate_F.p3d";
+        previewPosition[] = {0.796787,1,0.22};
+        previewScale = 0.035;
+        previewVector = 0;
+    };
+    class KitWaterPump : Kit
+    {
+        recipe[] = {{"CinderBlocks",4},{"MortarBucket",4},{"ItemPipe",2},{"ItemCorrugated",2}};
+		model = "\A3\Structures_F\Civ\Accessories\Water_source_F.p3d";
+        previewPosition[] = {0.796787,1,0.25};
+        previewScale = 0.08;
+        previewVector = 0;
+    };
 };
 
 /*[[[end]]]*/


### PR DESCRIPTION
This update facilitates the crafting of the new building kits and building them. All new items are included with the exception of the *crafting* (the interactions with the building kit and the CfgBaseBuilding entries are there for them) of the alternate camp fire, the fuel pump (could be OP for many servers) and the camo nets (due to deletion issues). These could perhaps be left for server owners to add serverside themselves (which I definitely will be doing). Let me know if you want them in the release by default, if so I will add them (already have all the recipes). 