### PR TITLE
mission.sqm fixes

### DIFF
--- a/Sources/mpmissions/epoch.Altis/mission.sqm
+++ b/Sources/mpmissions/epoch.Altis/mission.sqm
@@ -6076,35 +6076,5 @@ class Mission
 			};
 			id=401;
 		};
-		class Item203
-		{
-			dataType="Group";
-			side="Civilian";
-			class Entities
-			{
-				items=1;
-				class Item0
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={23598.076,3.1900001,17997.086};
-						angles[]={0,4.7169838,0};
-					};
-					side="Civilian";
-					flags=3;
-					class Attributes
-					{
-						isPlayable=1;
-					};
-					id=404;
-					type="VirtualMan_EPOCH";
-				};
-			};
-			class Attributes
-			{
-			};
-			id=403;
-		};
 	};
 };

--- a/Sources/mpmissions/epoch.Australia/mission.sqm
+++ b/Sources/mpmissions/epoch.Australia/mission.sqm
@@ -6076,35 +6076,5 @@ class Mission
 			};
 			id=401;
 		};
-		class Item203
-		{
-			dataType="Group";
-			side="Civilian";
-			class Entities
-			{
-				items=1;
-				class Item0
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={30400,0,6100};
-						angles[]={0,4.7169838,0};
-					};
-					side="Civilian";
-					flags=3;
-					class Attributes
-					{
-						isPlayable=1;
-					};
-					id=404;
-					type="VirtualMan_EPOCH";
-				};
-			};
-			class Attributes
-			{
-			};
-			id=403;
-		};
 	};
 };

--- a/Sources/mpmissions/epoch.Bootcamp_ACR/mission.sqm
+++ b/Sources/mpmissions/epoch.Bootcamp_ACR/mission.sqm
@@ -6084,35 +6084,5 @@ class Mission
 			};
 			id=402;
 		};
-		class Item204
-		{
-			dataType="Group";
-			side="Civilian";
-			class Entities
-			{
-				items=1;
-				class Item0
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={30.454964,0,24.159744};
-						angles[]={0,4.7169838,0};
-					};
-					side="Civilian";
-					flags=3;
-					class Attributes
-					{
-						isPlayable=1;
-					};
-					id=405;
-					type="VirtualMan_EPOCH";
-				};
-			};
-			class Attributes
-			{
-			};
-			id=404;
-		};
 	};
 };

--- a/Sources/mpmissions/epoch.Bornholm/mission.sqm
+++ b/Sources/mpmissions/epoch.Bornholm/mission.sqm
@@ -6076,35 +6076,5 @@ class Mission
 			};
 			id=401;
 		};
-		class Item203
-		{
-			dataType="Group";
-			side="Civilian";
-			class Entities
-			{
-				items=1;
-				class Item0
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={13812.688,0,6877.9214};
-						angles[]={0,4.7169838,0};
-					};
-					side="Civilian";
-					flags=3;
-					class Attributes
-					{
-						isPlayable=1;
-					};
-					id=404;
-					type="VirtualMan_EPOCH";
-				};
-			};
-			class Attributes
-			{
-			};
-			id=403;
-		};
 	};
 };

--- a/Sources/mpmissions/epoch.Chernarus/mission.sqm
+++ b/Sources/mpmissions/epoch.Chernarus/mission.sqm
@@ -6077,35 +6077,5 @@ class Mission
 			};
 			id=401;
 		};
-		class Item203
-		{
-			dataType="Group";
-			side="Civilian";
-			class Entities
-			{
-				items=1;
-				class Item0
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={1024.8502,0,2023.5204};
-						angles[]={0,4.7169838,0};
-					};
-					side="Civilian";
-					flags=3;
-					class Attributes
-					{
-						isPlayable=1;
-					};
-					id=404;
-					type="VirtualMan_EPOCH";
-				};
-			};
-			class Attributes
-			{
-			};
-			id=403;
-		};
 	};
 };

--- a/Sources/mpmissions/epoch.ChernarusRedux/mission.sqm
+++ b/Sources/mpmissions/epoch.ChernarusRedux/mission.sqm
@@ -6077,35 +6077,5 @@ class Mission
 			};
 			id=401;
 		};
-		class Item203
-		{
-			dataType="Group";
-			side="Civilian";
-			class Entities
-			{
-				items=1;
-				class Item0
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={1024.8502,0,2023.5204};
-						angles[]={0,4.7169838,0};
-					};
-					side="Civilian";
-					flags=3;
-					class Attributes
-					{
-						isPlayable=1;
-					};
-					id=404;
-					type="VirtualMan_EPOCH";
-				};
-			};
-			class Attributes
-			{
-			};
-			id=403;
-		};
 	};
 };

--- a/Sources/mpmissions/epoch.Chernarus_Summer/mission.sqm
+++ b/Sources/mpmissions/epoch.Chernarus_Summer/mission.sqm
@@ -6077,35 +6077,5 @@ class Mission
 			};
 			id=401;
 		};
-		class Item203
-		{
-			dataType="Group";
-			side="Civilian";
-			class Entities
-			{
-				items=1;
-				class Item0
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={1024.8502,0,2023.5204};
-						angles[]={0,4.7169838,0};
-					};
-					side="Civilian";
-					flags=3;
-					class Attributes
-					{
-						isPlayable=1;
-					};
-					id=404;
-					type="VirtualMan_EPOCH";
-				};
-			};
-			class Attributes
-			{
-			};
-			id=403;
-		};
 	};
 };

--- a/Sources/mpmissions/epoch.Desert_E/mission.sqm
+++ b/Sources/mpmissions/epoch.Desert_E/mission.sqm
@@ -6085,35 +6085,5 @@ class Mission
 			};
 			id=402;
 		};
-		class Item204
-		{
-			dataType="Group";
-			side="Civilian";
-			class Entities
-			{
-				items=1;
-				class Item0
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8.4882975,0,8.1249542};
-						angles[]={0,4.7169838,0};
-					};
-					side="Civilian";
-					flags=3;
-					class Attributes
-					{
-						isPlayable=1;
-					};
-					id=405;
-					type="VirtualMan_EPOCH";
-				};
-			};
-			class Attributes
-			{
-			};
-			id=404;
-		};
 	};
 };

--- a/Sources/mpmissions/epoch.Esseker/mission.sqm
+++ b/Sources/mpmissions/epoch.Esseker/mission.sqm
@@ -6077,35 +6077,5 @@ class Mission
 			};
 			id=401;
 		};
-		class Item203
-		{
-			dataType="Group";
-			side="Civilian";
-			class Entities
-			{
-				items=1;
-				class Item0
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={263.93359,0,1416.0308};
-						angles[]={0,4.7169838,0};
-					};
-					side="Civilian";
-					flags=3;
-					class Attributes
-					{
-						isPlayable=1;
-					};
-					id=404;
-					type="VirtualMan_EPOCH";
-				};
-			};
-			class Attributes
-			{
-			};
-			id=403;
-		};
 	};
 };

--- a/Sources/mpmissions/epoch.Malden/mission.sqm
+++ b/Sources/mpmissions/epoch.Malden/mission.sqm
@@ -6092,35 +6092,5 @@ class Mission
 			};
 			id=403;
 		};
-		class Item205
-		{
-			dataType="Group";
-			side="Civilian";
-			class Entities
-			{
-				items=1;
-				class Item0
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={10090.576,0,2139.79};
-						angles[]={0,4.7169838,0};
-					};
-					side="Civilian";
-					flags=3;
-					class Attributes
-					{
-						isPlayable=1;
-					};
-					id=406;
-					type="VirtualMan_EPOCH";
-				};
-			};
-			class Attributes
-			{
-			};
-			id=405;
-		};
 	};
 };

--- a/Sources/mpmissions/epoch.Mountains_ACR/mission.sqm
+++ b/Sources/mpmissions/epoch.Mountains_ACR/mission.sqm
@@ -6101,35 +6101,5 @@ class Mission
 			};
 			id=404;
 		};
-		class Item206
-		{
-			dataType="Group";
-			side="Civilian";
-			class Entities
-			{
-				items=1;
-				class Item0
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={4864.4897,0,397.39026};
-						angles[]={0,4.7169838,0};
-					};
-					side="Civilian";
-					flags=3;
-					class Attributes
-					{
-						isPlayable=1;
-					};
-					id=407;
-					type="VirtualMan_EPOCH";
-				};
-			};
-			class Attributes
-			{
-			};
-			id=406;
-		};
 	};
 };

--- a/Sources/mpmissions/epoch.Napf/mission.sqm
+++ b/Sources/mpmissions/epoch.Napf/mission.sqm
@@ -6099,35 +6099,5 @@ class Mission
 			};
 			id=404;
 		};
-		class Item206
-		{
-			dataType="Group";
-			side="Civilian";
-			class Entities
-			{
-				items=1;
-				class Item0
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={4712.0864,8.8047247,16664.449};
-						angles[]={0,4.7169838,0};
-					};
-					side="Civilian";
-					flags=3;
-					class Attributes
-					{
-						isPlayable=1;
-					};
-					id=407;
-					type="VirtualMan_EPOCH";
-				};
-			};
-			class Attributes
-			{
-			};
-			id=406;
-		};
 	};
 };

--- a/Sources/mpmissions/epoch.Porto/mission.sqm
+++ b/Sources/mpmissions/epoch.Porto/mission.sqm
@@ -6085,35 +6085,5 @@ class Mission
 			};
 			id=402;
 		};
-		class Item204
-		{
-			dataType="Group";
-			side="Civilian";
-			class Entities
-			{
-				items=1;
-				class Item0
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={808.42041,0,2754.4238};
-						angles[]={0,4.7169838,0};
-					};
-					side="Civilian";
-					flags=3;
-					class Attributes
-					{
-						isPlayable=1;
-					};
-					id=405;
-					type="VirtualMan_EPOCH";
-				};
-			};
-			class Attributes
-			{
-			};
-			id=404;
-		};
 	};
 };

--- a/Sources/mpmissions/epoch.ProvingGrounds_PMC/mission.sqm
+++ b/Sources/mpmissions/epoch.ProvingGrounds_PMC/mission.sqm
@@ -6085,35 +6085,5 @@ class Mission
 			};
 			id=402;
 		};
-		class Item204
-		{
-			dataType="Group";
-			side="Civilian";
-			class Entities
-			{
-				items=1;
-				class Item0
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8.4882975,0,8.1249542};
-						angles[]={0,4.7169838,0};
-					};
-					side="Civilian";
-					flags=3;
-					class Attributes
-					{
-						isPlayable=1;
-					};
-					id=405;
-					type="VirtualMan_EPOCH";
-				};
-			};
-			class Attributes
-			{
-			};
-			id=404;
-		};
 	};
 };

--- a/Sources/mpmissions/epoch.Sara/mission.sqm
+++ b/Sources/mpmissions/epoch.Sara/mission.sqm
@@ -6101,35 +6101,5 @@ class Mission
 			};
 			id=404;
 		};
-		class Item206
-		{
-			dataType="Group";
-			side="Civilian";
-			class Entities
-			{
-				items=1;
-				class Item0
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={9466.5723,0,3495.4368};
-						angles[]={0,4.7169838,0};
-					};
-					side="Civilian";
-					flags=3;
-					class Attributes
-					{
-						isPlayable=1;
-					};
-					id=407;
-					type="VirtualMan_EPOCH";
-				};
-			};
-			class Attributes
-			{
-			};
-			id=406;
-		};
 	};
 };

--- a/Sources/mpmissions/epoch.Sara_dbe1/mission.sqm
+++ b/Sources/mpmissions/epoch.Sara_dbe1/mission.sqm
@@ -6101,35 +6101,5 @@ class Mission
 			};
 			id=404;
 		};
-		class Item206
-		{
-			dataType="Group";
-			side="Civilian";
-			class Entities
-			{
-				items=1;
-				class Item0
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={9466.5723,0,3495.4368};
-						angles[]={0,4.7169838,0};
-					};
-					side="Civilian";
-					flags=3;
-					class Attributes
-					{
-						isPlayable=1;
-					};
-					id=407;
-					type="VirtualMan_EPOCH";
-				};
-			};
-			class Attributes
-			{
-			};
-			id=406;
-		};
 	};
 };

--- a/Sources/mpmissions/epoch.Shapur_BAF/mission.sqm
+++ b/Sources/mpmissions/epoch.Shapur_BAF/mission.sqm
@@ -6085,35 +6085,5 @@ class Mission
 			};
 			id=402;
 		};
-		class Item204
-		{
-			dataType="Group";
-			side="Civilian";
-			class Entities
-			{
-				items=1;
-				class Item0
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8.5185719,0,8.1347198};
-						angles[]={0,4.7169838,0};
-					};
-					side="Civilian";
-					flags=3;
-					class Attributes
-					{
-						isPlayable=1;
-					};
-					id=405;
-					type="VirtualMan_EPOCH";
-				};
-			};
-			class Attributes
-			{
-			};
-			id=404;
-		};
 	};
 };

--- a/Sources/mpmissions/epoch.Stratis/mission.sqm
+++ b/Sources/mpmissions/epoch.Stratis/mission.sqm
@@ -6077,35 +6077,5 @@ class Mission
 			};
 			id=401;
 		};
-		class Item203
-		{
-			dataType="Group";
-			side="Civilian";
-			class Entities
-			{
-				items=1;
-				class Item0
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={1719.5787,0,5121.1045};
-						angles[]={0,4.7169838,0};
-					};
-					side="Civilian";
-					flags=3;
-					class Attributes
-					{
-						isPlayable=1;
-					};
-					id=404;
-					type="VirtualMan_EPOCH";
-				};
-			};
-			class Attributes
-			{
-			};
-			id=403;
-		};
 	};
 };

--- a/Sources/mpmissions/epoch.Takistan/mission.sqm
+++ b/Sources/mpmissions/epoch.Takistan/mission.sqm
@@ -6077,35 +6077,5 @@ class Mission
 			};
 			id=401;
 		};
-		class Item203
-		{
-			dataType="Group";
-			side="Civilian";
-			class Entities
-			{
-				items=1;
-				class Item0
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={-107.9753,0,-91.194214};
-						angles[]={0,4.7169838,0};
-					};
-					side="Civilian";
-					flags=3;
-					class Attributes
-					{
-						isPlayable=1;
-					};
-					id=404;
-					type="VirtualMan_EPOCH";
-				};
-			};
-			class Attributes
-			{
-			};
-			id=403;
-		};
 	};
 };

--- a/Sources/mpmissions/epoch.Tanoa/mission.sqm
+++ b/Sources/mpmissions/epoch.Tanoa/mission.sqm
@@ -6095,35 +6095,5 @@ class Mission
 			};
 			id=402;
 		};
-		class Item204
-		{
-			dataType="Group";
-			side="Civilian";
-			class Entities
-			{
-				items=1;
-				class Item0
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={9969.2129,298.72415,12166.665};
-						angles[]={0,4.7169838,0};
-					};
-					side="Civilian";
-					flags=7;
-					class Attributes
-					{
-						isPlayable=1;
-					};
-					id=405;
-					type="VirtualMan_EPOCH";
-				};
-			};
-			class Attributes
-			{
-			};
-			id=404;
-		};
 	};
 };

--- a/Sources/mpmissions/epoch.VR/mission.sqm
+++ b/Sources/mpmissions/epoch.VR/mission.sqm
@@ -6077,35 +6077,5 @@ class Mission
 			};
 			id=401;
 		};
-		class Item203
-		{
-			dataType="Group";
-			side="Civilian";
-			class Entities
-			{
-				items=1;
-				class Item0
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={1719.5787,0,5121.1045};
-						angles[]={0,4.7169838,0};
-					};
-					side="Civilian";
-					flags=3;
-					class Attributes
-					{
-						isPlayable=1;
-					};
-					id=404;
-					type="VirtualMan_EPOCH";
-				};
-			};
-			class Attributes
-			{
-			};
-			id=403;
-		};
 	};
 };

--- a/Sources/mpmissions/epoch.Woodland_ACR/mission.sqm
+++ b/Sources/mpmissions/epoch.Woodland_ACR/mission.sqm
@@ -6101,35 +6101,5 @@ class Mission
 			};
 			id=404;
 		};
-		class Item206
-		{
-			dataType="Group";
-			side="Civilian";
-			class Entities
-			{
-				items=1;
-				class Item0
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={1270.4408,0,234.18149};
-						angles[]={0,4.7169838,0};
-					};
-					side="Civilian";
-					flags=3;
-					class Attributes
-					{
-						isPlayable=1;
-					};
-					id=407;
-					type="VirtualMan_EPOCH";
-				};
-			};
-			class Attributes
-			{
-			};
-			id=406;
-		};
 	};
 };

--- a/Sources/mpmissions/epoch.Zargabad/mission.sqm
+++ b/Sources/mpmissions/epoch.Zargabad/mission.sqm
@@ -6093,35 +6093,5 @@ class Mission
 			};
 			id=403;
 		};
-		class Item205
-		{
-			dataType="Group";
-			side="Civilian";
-			class Entities
-			{
-				items=1;
-				class Item0
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={4331.02,0,148.62354};
-						angles[]={0,4.7169838,0};
-					};
-					side="Civilian";
-					flags=3;
-					class Attributes
-					{
-						isPlayable=1;
-					};
-					id=406;
-					type="VirtualMan_EPOCH";
-				};
-			};
-			class Attributes
-			{
-			};
-			id=405;
-		};
 	};
 };

--- a/Sources/mpmissions/epoch.utes/mission.sqm
+++ b/Sources/mpmissions/epoch.utes/mission.sqm
@@ -6085,35 +6085,5 @@ class Mission
 			};
 			id=402;
 		};
-		class Item204
-		{
-			dataType="Group";
-			side="Civilian";
-			class Entities
-			{
-				items=1;
-				class Item0
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={4154.1626,0,3645.7505};
-						angles[]={0,4.7169838,0};
-					};
-					side="Civilian";
-					flags=3;
-					class Attributes
-					{
-						isPlayable=1;
-					};
-					id=405;
-					type="VirtualMan_EPOCH";
-				};
-			};
-			class Attributes
-			{
-			};
-			id=404;
-		};
 	};
 };

--- a/Sources/mpmissions/epoch_RyanZed.Tanoa/mission.sqm
+++ b/Sources/mpmissions/epoch_RyanZed.Tanoa/mission.sqm
@@ -6101,35 +6101,5 @@ class Mission
 			};
 			id=402;
 		};
-		class Item204
-		{
-			dataType="Group";
-			side="Civilian";
-			class Entities
-			{
-				items=1;
-				class Item0
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={9969.2129,298.72415,12166.665};
-						angles[]={0,4.7169838,0};
-					};
-					side="Civilian";
-					flags=7;
-					class Attributes
-					{
-						isPlayable=1;
-					};
-					id=405;
-					type="VirtualMan_EPOCH";
-				};
-			};
-			class Attributes
-			{
-			};
-			id=404;
-		};
 	};
 };


### PR DESCRIPTION
Removed the extra player slot from all mission.sqm files that was generating the following warning in the RPT files:

`15:01:02 Mission epoch.ChernarusRedux: Number of roles (201) is different from 'description.ext::Header::maxPlayer' (200)
`