### PR TITLE
Add code to handle enable/disable vehicle TIE

### DIFF
--- a/Server_Install_Pack/@epochhive/epochconfig.hpp
+++ b/Server_Install_Pack/@epochhive/epochconfig.hpp
@@ -61,6 +61,7 @@ removevehmagazinesturret[] = {	// Remove these Magazines from the given Turret f
 	{"24Rnd_missiles",{-1}},
 	{"200Rnd_40mm_G_belt",{0}}
 };
+disableVehicleTIE = "true";
 
 // BaseBuilding
 UseIndestructible = "false";			// Enable / Disable Indestructible BaseObjects

--- a/Sources/epoch_server/compile/epoch_vehicle/EPOCH_load_vehicles.sqf
+++ b/Sources/epoch_server/compile/epoch_vehicle/EPOCH_load_vehicles.sqf
@@ -32,6 +32,7 @@ _immuneIfStartInBase = [_serverSettingsConfig, "immuneIfStartInBase", true] call
 
 _removeweapons = [_serverSettingsConfig, "removevehweapons", []] call EPOCH_fnc_returnConfigEntry;
 _removemagazinesturret = [_serverSettingsConfig, "removevehmagazinesturret", []] call EPOCH_fnc_returnConfigEntry;
+_disableVehicleTIE = [_serverSettingsConfig, "disableVehicleTIE", true] call EPOCH_fnc_returnConfigEntry;
 
 for "_i" from 1 to _maxVehicleLimit do {
 	_vehicleSlotIndex = EPOCH_VehicleSlots pushBack str(_i);
@@ -141,7 +142,9 @@ for "_i" from 1 to _maxVehicleLimit do {
 							_vehicle setvariable ["VEHICLE_BASECLASS",_baseClass];
 						};
 						// disable thermal imaging equipment
-						_vehicle disableTIEquipment true;
+						if (_disableVehicleTIE) then {
+							_vehicle disableTIEquipment true;
+						};
 						// lock all vehicles
 						_vehicle lock true;
 						// load vehicle inventory

--- a/Sources/epoch_server/compile/epoch_vehicle/EPOCH_load_vehicles_old.sqf
+++ b/Sources/epoch_server/compile/epoch_vehicle/EPOCH_load_vehicles_old.sqf
@@ -28,6 +28,7 @@ _simulationHandler = [_serverSettingsConfig, "simulationHandlerOld", false] call
 _immuneVehicleSpawn = [_serverSettingsConfig, "immuneVehicleSpawn", false] call EPOCH_fnc_returnConfigEntry;
 _removeweapons = [_serverSettingsConfig, "removevehweapons", []] call EPOCH_fnc_returnConfigEntry;
 _removemagazinesturret = [_serverSettingsConfig, "removevehmagazinesturret", []] call EPOCH_fnc_returnConfigEntry;
+_disableVehicleTIE = [_serverSettingsConfig, "disableVehicleTIE", true] call EPOCH_fnc_returnConfigEntry;
 
 for "_i" from 1 to _maxVehicleLimit do {
 	_vehicleSlotIndex = EPOCH_VehicleSlots pushBack str(_i);
@@ -131,7 +132,9 @@ for "_i" from 1 to _maxVehicleLimit do {
 						} foreach _removemagazinesturret;
 					};
 
-					_vehicle disableTIEquipment true;
+					if (_disableVehicleTIE) then {
+						_vehicle disableTIEquipment true;
+					};
 
 					_vehicle lock true;
 

--- a/Sources/epoch_server/compile/epoch_vehicle/EPOCH_server_upgrade_vehicle.sqf
+++ b/Sources/epoch_server/compile/epoch_vehicle/EPOCH_server_upgrade_vehicle.sqf
@@ -116,6 +116,10 @@ clearItemCargoGlobal	  _newveh;
 _serverSettingsConfig = configFile >> "CfgEpochServer";
 _removeweapons = [_serverSettingsConfig, "removevehweapons", []] call EPOCH_fnc_returnConfigEntry;
 _removemagazinesturret = [_serverSettingsConfig, "removevehmagazinesturret", []] call EPOCH_fnc_returnConfigEntry;
+_disableVehicleTIE = [_serverSettingsConfig, "disableVehicleTIE", true] call EPOCH_fnc_returnConfigEntry;
+if (_disableVehicleTIE) then {
+	_newVeh disableTIEquipment true;
+};
 if !(_removeweapons isequalto []) then {
 	{
 		_newVeh removeWeaponGlobal _x;

--- a/Sources/epoch_server/compile/epoch_vehicle/EPOCH_spawn_vehicle.sqf
+++ b/Sources/epoch_server/compile/epoch_vehicle/EPOCH_spawn_vehicle.sqf
@@ -20,6 +20,7 @@ if !(isClass (configFile >> "CfgVehicles" >> _vehClass)) exitWith {objNull};
 _serverSettingsConfig = configFile >> "CfgEpochServer";
 _removeweapons = [_serverSettingsConfig, "removevehweapons", []] call EPOCH_fnc_returnConfigEntry;
 _removemagazinesturret = [_serverSettingsConfig, "removevehmagazinesturret", []] call EPOCH_fnc_returnConfigEntry;
+_disableVehicleTIE = [_serverSettingsConfig, "disableVehicleTIE", true] call EPOCH_fnc_returnConfigEntry;
 _vehObj = createVehicle[_vehClass, _position, [], 0, _can_collide];
 // turn off BIS randomization
 _vehObj setVariable ["BIS_enableRandomization", false];
@@ -62,7 +63,9 @@ if !(isNull _vehObj) then{
 	};
 
 	// Disable Termal Equipment
-	_vehObj disableTIEquipment true;
+	if (_disableVehicleTIE) then {
+		_vehObj disableTIEquipment true;
+	};
 
 	// Vehicle Lock
 	_vehObj lock _locked;

--- a/Sources/epoch_server/init/server_securityfunctions.sqf
+++ b/Sources/epoch_server/init/server_securityfunctions.sqf
@@ -1140,6 +1140,7 @@ call compile ("'"+_skn_doAdminRequest+"' addPublicVariableEventHandler {
 					_serverSettingsConfig = configFile >> 'CfgEpochServer';
 					_removeweapons = [_serverSettingsConfig, 'removevehweapons', []] call EPOCH_fnc_returnConfigEntry;
 					_removemagazinesturret = [_serverSettingsConfig, 'removevehmagazinesturret', []] call EPOCH_fnc_returnConfigEntry;
+					_disableVehicleTIE = [_serverSettingsConfig, 'disableVehicleTIE', true] call EPOCH_fnc_returnConfigEntry;
 					_position = getPosATL _target;
 
 					_slot = EPOCH_VehicleSlots select 0;
@@ -1151,7 +1152,9 @@ call compile ("'"+_skn_doAdminRequest+"' addPublicVariableEventHandler {
 					_vehObj call EPOCH_server_setVToken;
 					addToRemainsCollector[_vehObj];
 
-					_vehObj disableTIEquipment true;
+					if (_disableVehicleTIE) then {
+						_vehObj disableTIEquipment true;
+					};
 
 					clearWeaponCargoGlobal	_vehObj;
 					clearMagazineCargoGlobal  _vehObj;


### PR DESCRIPTION
Many server owners, including myself, run militarized servers and some of us enable Thermal Imaging Equipment each time that there is a new version of Epoch by going in and changing the server side code.

This change adds a server side variable in CfgEpochServer.hpp called disableVehicleTIE which defaults to true. If left at the default then vehicles will spawn and load with TIE turned off, otherwise they will be turned on.

I have tested both the true and false cases for vehicle spawns and loads and for spawns via the standard Epoch anti-hack. Hopefully did not miss anything.