### PR TITLE
Add variable to control accelerated HTA Loss

### DIFF
--- a/Sources/epoch_code/compile/setup/masterLoop/Event2.sqf
+++ b/Sources/epoch_code/compile/setup/masterLoop/Event2.sqf
@@ -172,9 +172,9 @@ if (_wet) then {
 };
 
 // Hunger / Thirst
-_hungerlossRate = _baseHungerLoss * timeMultiplier;
-_thirstlossRate = _baseThirstLoss * timeMultiplier;
-_alcoholLossRate = _baseAlcoholLoss * timeMultiplier;
+_hungerlossRate = _baseHungerLoss * _lossMultiplier;
+_thirstlossRate = _baseThirstLoss * _lossMultiplier;
+_alcoholLossRate = _baseAlcoholLoss * _lossMultiplier;
 
 // Increase hunger if player is Fatigued
 _playerStamina = missionNamespace getVariable [_playerStaminaKey, _playerStaminaDefault];

--- a/Sources/epoch_code/compile/setup/masterLoop/init.sqf
+++ b/Sources/epoch_code/compile/setup/masterLoop/init.sqf
@@ -117,6 +117,7 @@ _antagonistRndChance = ["CfgEpochClient", "antagonistRngChance", 100] call EPOCH
 _baseHungerLoss = ["CfgEpochClient", "baseHungerLoss", 2] call EPOCH_fnc_returnConfigEntryV2;
 _baseThirstLoss = ["CfgEpochClient", "baseThirstLoss", 2] call EPOCH_fnc_returnConfigEntryV2;
 _baseAlcoholLoss = ["CfgEpochClient", "baseAlcoholLoss", 0.17] call EPOCH_fnc_returnConfigEntryV2;
+_lossMultiplier = if (["CfgEpochClient", "accelerateHTALoss", true] call EPOCH_fnc_returnConfigEntryV2) then {timeMultiplier} else {1};
 _energyCostNV = ["CfgEpochClient", "energyCostNV", 3] call EPOCH_fnc_returnConfigEntryV2;
 _energyRegenMax = ["CfgEpochClient", "energyRegenMax", 5] call EPOCH_fnc_returnConfigEntryV2;
 _energyRange = ["CfgEpochClient", "energyRange", 75] call EPOCH_fnc_returnConfigEntryV2;

--- a/Sources/epoch_config/Configs/CfgEpochClient.hpp
+++ b/Sources/epoch_config/Configs/CfgEpochClient.hpp
@@ -25,6 +25,7 @@ class CfgEpochClient
 
     baseHungerLoss = 2; // increase number to speed up rate of Hunger loss
     baseThirstLoss = 2; // increase number to speed up rate of Thirst loss
+    accelerateHTALoss = "true"; // use server's time acceleration to increase the rate of Hunger, Thirst and Alcohol loss
 
     buildingNearbyMilitary = 0; //1 to allow building nearby
     buildingNearbyMilitaryRange = 300; //Define radius of blocked area


### PR DESCRIPTION
As per previous pull request, this adds a new CfgEpochClient variable, accelerateHTALoss (default value = true) that determines whether time acceleration is applied to the rate of loss of Hunger, Thirst and Alcohol. New pull request uses the more streamlined code as suggested by @Ignatz-HeMan 