### PR TITLE
Fix and enhancement for radiation effects post processing

### DIFF
--- a/Sources/epoch_code/compile/setup/masterLoop/Event2.sqf
+++ b/Sources/epoch_code/compile/setup/masterLoop/Event2.sqf
@@ -44,8 +44,8 @@ if (_playerAlcohol > 20) then {
 
 // Sets visual effect
 _playerRadiation = missionNamespace getVariable [_playerRadiationKey, _playerRadiationDefault];
-if (_playerRadiation > 1) then {
-	_radiationVal = linearConversion [0,100,_playerRadiation,1,10,true];
+if (_playerRadiation > _radiationEffectsThreshold) then {
+	_radiationVal = linearConversion [0,100,_playerRadiation,0,10,true];
 	[(ceil _radiationVal)/10, 2] call epoch_setRadiation;
 } else {
 	[0, 2] call epoch_setRadiation;

--- a/Sources/epoch_code/compile/setup/masterLoop/init.sqf
+++ b/Sources/epoch_code/compile/setup/masterLoop/init.sqf
@@ -102,6 +102,8 @@ if (isNil "EPOCH_display_setup_complete") then {
 // Background radiation
 _outOfBoundsRadiation = ["CfgEpochClient", "outOfBoundsRadiation", 10] call EPOCH_fnc_returnConfigEntryV2;
 _radsLevel = 0;
+// Radiation screen effects threshold
+_radiationEffectsThreshold = ["CfgEpochClient", "radiationEffectsThreshold", 10] call EPOCH_fnc_returnConfigEntryV2;
 
 _prevEquippedItem = [];
 _damagePlayer = damage player;

--- a/Sources/epoch_code/gui/scripts/post_process/Epoch_setRadiation.sqf
+++ b/Sources/epoch_code/gui/scripts/post_process/Epoch_setRadiation.sqf
@@ -42,9 +42,8 @@ switch _level do {
 	};
 	case 0.1:
 	{
-		[(rmx_var_RadiationHandles select 0), _speed, [0.185533,1,1,1,0,true]] call epoch_postprocessAdjust;
-		[(rmx_var_RadiationHandles select 1), _speed, [1,1,0,0,0,0,0,0,0,0,1,0,0,0,0]] call epoch_postprocessAdjust;
-		[(rmx_var_RadiationHandles select 2), _speed, [0,0,0]] call epoch_postprocessAdjust;
+		rmx_var_RadiationHandles call epoch_postprocessDestroy;
+		rmx_var_RadiationHandles = nil;
 	};
 	case 0.2:
 	{

--- a/Sources/epoch_config/Configs/CfgEpochClient.hpp
+++ b/Sources/epoch_config/Configs/CfgEpochClient.hpp
@@ -23,6 +23,7 @@ class CfgEpochClient
 	radioactiveLocations[] = {"NameCityCapital", "NameCity", "Airport"}; // used for random radioactive locations and to suppress animal spawns within cities.
 	radiatedObjMaxFalloutDist = 125; // max distance radiated object can affect player (number in meters)
 	geigerCounterEnergyUsage = 10; // default loss of 10 energy every 10sec of use
+	radiationEffectsThreshold = 10; // default level for screen effects to indicate a player's rad dosage (0-100)
 
     baseHungerLoss = 2; // increase number to speed up rate of Hunger loss
     baseThirstLoss = 2; // increase number to speed up rate of Thirst loss


### PR DESCRIPTION
Fixed a couple of small issues determining screen post processing for radiation effects. Also added a new CfgEpochClient.hpp variable so server owners can set a threshold for displaying the effects (default is 10%)