### PR TITLE
Fav bar and accessories

### DIFF
--- a/Sources/epoch_code/compile/inventory/EPOCH_equip.sqf
+++ b/Sources/epoch_code/compile/inventory/EPOCH_equip.sqf
@@ -353,9 +353,9 @@ _fnc_dropEquipAccessories = {
 			_equipped call _fnc_dropItem;
 			(_loadout select _slot) set [_accessory,""];
 			player setUnitLoadout _loadout;
-			_return = 1;
+			_return = 2;
 		};
-		if (((toLower _equipped) != (toLower _item)) || _forceEquip && _return != 4) then {
+		if ((((toLower _equipped) != (toLower _item)) || _forceEquip) && _return != 4) then {
 			(_loadout select _slot) set [_accessory,_item];
 			player setUnitLoadout _loadout;
 			player addItem _equipped;


### PR DESCRIPTION
Fav Bar now returns "Not enough Space" message if there isn't enough space to store current accessory item with drop on ground disabled, and doesn't lose current item by swapping for new item.

Also returns "Not enough space, item dropped on the ground!" when drop is enabled and drops item on ground.