### PR TITLE
Missing brace

### DIFF
--- a/Sources/epoch_server/compile/epoch_server/EPOCH_server_createTeleport.sqf
+++ b/Sources/epoch_server/compile/epoch_server/EPOCH_server_createTeleport.sqf
@@ -102,7 +102,7 @@ if !(_debugBox isEqualTo "") then {
 	if((_deSimulate) || (_disableSim isEqualTo "true"))then{
 		_ep enableSimulationGlobal false;
 	};
-	if([configFile >> "CfgEpochServer", "enableDynamicSimulationSystem", true] call EPOCH_fnc_returnConfigEntry)then
+	if([configFile >> "CfgEpochServer", "enableDynamicSimulationSystem", true] call EPOCH_fnc_returnConfigEntry) then {
 		_ep enableDynamicSimulation (_dynSim isEqualTo "true");
 	};
 	_ep allowDamage (_allowDmg isEqualTo "true");


### PR DESCRIPTION
There's a opening brace missing, causing this error:
```
21:15:44 Error in expression <"true");
_ep setDamage (_dmg min 0.75);
} forEach(getArray(_configWorld >> "prop>
21:15:44   Error position: <} forEach(getArray(_configWorld >> "prop>
21:15:44   Error Missing {
21:15:44 File epoch_server\compile\epoch_server\EPOCH_server_createTeleport.sqf, line 110
21:15:44 Error in expression <"true");
_ep setDamage (_dmg min 0.75);
} forEach(getArray(_configWorld >> "prop>
21:15:44   Error position: <} forEach(getArray(_configWorld >> "prop>
21:15:44   Error Missing {
21:15:44 File epoch_server\compile\epoch_server\EPOCH_server_createTeleport.sqf, line 110
```