### PR TITLE
Fix check on whether DynamicDebris.sqf has run

### DIFF
--- a/Sources/epoch_server_debris_event/EpochEvents/DynamicDebris.sqf
+++ b/Sources/epoch_server_debris_event/EpochEvents/DynamicDebris.sqf
@@ -12,7 +12,7 @@
 private ["_allRoads","_allowDebris","_debris","_debrisCounter","_debrisLocations","_debrisLocationsKey","_debrisLocationsTMP","_debug","_disallowedLocations","_expiresDebris","_export","_instanceID","_intersections","_marker","_maxDebrisLimit","_nearbyLocations","_newDebrisCounter","_object","_offsetX","_offsetY","_position","_response","_rng","_rngChance","_scriptHiveKey","_seed","_selectedDebris","_upperPos","_worldSize"];
 //[[[end]]]
 // exit if already ran once.
-if (isNil "EPOCH_DynamicDebrisEnabled") exitWith {};
+if !(isNil "EPOCH_DynamicDebrisEnabled") exitWith {};
 EPOCH_DynamicDebrisEnabled = true;
 _debug = false;
 _expiresDebris = 604800;


### PR DESCRIPTION
The initial isNil() check in DynamicDebris.sqf actually prevents this script from running. This inverts to !isNil() to allow it to run at least once