### PR TITLE
Ambient water

### DIFF
--- a/Sources/epoch_config/Configs/CfgActionMenu/CfgActionMenu_core.hpp
+++ b/Sources/epoch_config/Configs/CfgActionMenu/CfgActionMenu_core.hpp
@@ -51,6 +51,7 @@ class CfgActionMenu
 		
 		dyna_AtHome = "call {_nearjammers = (nearestObjects[player, call EPOCH_JammerClasses, call EPOCH_MaxJammerRange]) select {player distance _x < (getnumber (getmissionconfig 'cfgEpochClient' >> 'CfgJammers' >> (typeof _x) >> 'buildingJammerRange'))};if (_nearjammers isEqualTo []) exitwith {false};_nearestJammer = _nearjammers select 0;((_nearestJammer getVariable['BUILD_OWNER', '-1']) in[getPlayerUID player, Epoch_my_GroupUID])}";
 		dyna_Watersource = "call {_nearObjects = nearestObjects [player, [], 2];_check = 'water';_ok = false;{if (alive _x) then {_ok = [_x, _check] call EPOCH_worldObjectType;};if (_ok) exitWith {};} forEach _nearObjects;_ok}";
+		dyna_DirtyWatersource = "((surfaceiswater position player) && (position player isFlatEmpty  [-1, -1, -1, -1, 0, true] isEqualTo []) && (getPosASL player select 2 > 2) && (getPosATL player select 2 < 0.1))";
 		dyna_Paintobj = "objnull"; // <--- internal use only!
 	};
 

--- a/Sources/epoch_config/Configs/CfgActionMenu/CfgActionMenu_self.hpp
+++ b/Sources/epoch_config/Configs/CfgActionMenu/CfgActionMenu_self.hpp
@@ -115,7 +115,7 @@ class base_mode_attach
 };
 class Drink
 {
-	condition = "dyna_Watersource";
+	condition = "dyna_Watersource || dyna_DirtyWatersource";
 	action = "if (currentweapon player == '') then {player playmove 'AinvPknlMstpSnonWnonDnon_Putdown_AmovPknlMstpSnonWnonDnon';}else {if (currentweapon player == handgunweapon player) then {player playmove 'AinvPknlMstpSrasWpstDnon_Putdown_AmovPknlMstpSrasWpstDnon';}else {	player playmove 'AinvPknlMstpSrasWrflDnon_Putdown_AmovPknlMstpSrasWrflDnon';};};{_output = _x call EPOCH_giveAttributes;if (_output != '') then {[_output, 5] call Epoch_message_stack;};} foreach [['Thirst',100],['Toxicity',1,1],['Stamina',10]];";
 	icon = "x\addons\a3_epoch_code\Data\UI\buttons\Drink.paa";
 	tooltip = "Drink";


### PR DESCRIPTION
These changes are a first step to add ambient map water sources such as ponds and streams, allowing players to drink from them. The checks prohibit the drinking of sea water however.

Thanks to @Ignatz-HeMan  for his suggestion to fix an issue I had had with piers...