### PR TITLE
Fix loot spawns for Ryan's Zombies in the Epoch Zed spawner

### DIFF
--- a/Sources/epoch_server/compile/epoch_looting/EPOCH_server_lootAnimal.sqf
+++ b/Sources/epoch_server/compile/epoch_looting/EPOCH_server_lootAnimal.sqf
@@ -25,6 +25,9 @@ if !(isNull _object) then {
 	if (_classOverride != "") then {
 		_objectClass = _classOverride;
 	};
+	if ((_object isKindOf "RyanZombieC_man_1") || (_object isKindOf "RyanZombieB_Soldier_base_F")) then {
+		_objectClass = "EPOCH_RyanZombie_1";
+	};
 	deleteVehicle _object;
 	_item = createVehicle["groundWeaponHolder", [0,0,0], [], 0.0, "CAN_COLLIDE"];
 	if (_objectClass isequalto "GreatWhite_F") then {


### PR DESCRIPTION
Fixed the issue with vanilla Ryan Zombies in the Zed spawner not spawning correct zombie loot (they spawn loot from the default SeaFood table instead)