### PR TITLE
default to x64 arma3server binary

### DIFF
--- a/Server_Install_Pack/epoch_linux_startscript.sh
+++ b/Server_Install_Pack/epoch_linux_startscript.sh
@@ -48,7 +48,7 @@ PROFILES=${NAME}
 PIDFILE=${ARMA_DIR}/${PORT}.pid
 RUNFILE=${ARMA_DIR}/${PORT}.run
 LOGFILE=${LOG_DIR}/port_${PORT}.`date +%d.%m.%y_%H%M`.log
-SERVER=${ARMA_DIR}/arma3server
+SERVER=${ARMA_DIR}/arma3server_x64
 #=======================================================================
 ulimit -c 1000000
 


### PR DESCRIPTION
I had days of headache getting an Arma3 Epoch server to run on Linux.

I ended up being stuck here:

After I fixed redis it still did not work.

```
15:47:28 "Epoch: Starting ArmA3 Epoch Server, Version 1.3.3. Note: If server crashes directly after this point check that Redis is running and the connection info is correct."
15:47:28 Call extension 'epochserver' could not be loaded
15:47:28 Call extension 'epochserver' could not be loaded
15:47:28 "Epoch: Server DLL mismatch! Current:  Needed: 0.6.0.0"
15:47:28 "Epoch: Server DLL mismatch! Current:  Needed: 0.6.0.0"
15:47:28 "Epoch: Server DLL mismatch! Current:  Needed: 0.6.0.0"
15:47:28 "Epoch: Server DLL mismatch! Current:  Needed: 0.6.0.0"
15:47:28 "Epoch: Server DLL mismatch! Current:  Needed: 0.6.0.0"
15:47:28 "Epoch: Server DLL mismatch! Current:  Needed: 0.6.0.0"
15:47:28 "Epoch: Server DLL mismatch! Current:  Needed: 0.6.0.0"
15:47:28 "Epoch: Server DLL mismatch! Current:  Needed: 0.6.0.0"
15:47:28 "Epoch: Server DLL mismatch! Current:  Needed: 0.6.0.0"
15:47:28 "Epoch: Server DLL mismatch! Current:  Needed: 0.6.0.0"
15:47:28 "Epoch: Server DLL mismatch! Current:  Needed: 0.6.0.0"
15:47:28 "Epoch: Server DLL mismatch! Current:  Needed: 0.6.0.0"
15:47:28 "Epoch: Server DLL mismatch! Current:  Needed: 0.6.0.0"
15:47:28 "Epoch: Server DLL mismatch! Current:  Needed: 0.6.0.0"
15:47:28 "Epoch: Server DLL mismatch! Current:  Needed: 0.6.0.0"
15:47:28 "Epoch: Server DLL mismatch! Current:  Needed: 0.6.0.0"
```

I unpacked the `epoch_server.pbo` with the great [PboViewer](https://github.com/SteezCram/PboViewer).
And identified this line via the error message.
```
if (("epochserver" callExtension "") != _hiveVersion) exitWith {
    format["Epoch: Server DLL mismatch! Current: %1 Needed: %2", "epochserver" callExtension "",_hiveVersion] call _abortAndError;
};
```
Comparing that with the [documentation of callExtension](https://community.bistudio.com/wiki/callExtension) it seems that the `epochserver.so` simply does not return anything.

I already knew that the `.so` file was moving it gives a different error message.

*32bit vs 64bit calling conventions?*

There is also a `epochserver_x64.so`. Does it use the wrong one?
I renamed it and got a new error message, about calling a 64bit `.so` from a 32bit executable.

*Why am I running a 32bit executable?*

There is also a 64bit arma3server executable.

Let's try this.
**It works! 🎉** 

This is one of the most subtle issues I have ever run into.
What seems to be happening is:
The `epoch_linux_startscript.sh` runs the 32bit arma3server executable because it is hardcoded in there.
The OS happily does this, because all x64 CPUs have some backwards comparability mode to run 32bit binaries.
Only when calling back into a shared object (`.so`) from the `epoch_server.pbo` we get some calling or argument passing convention mismatch, thus `epoch_server.so` returning nothing. Which is insanely subtle.

therefore I suggest to default for the x64 arma3server executable. First, in 2025 I can not imagine anyone running an arma server (or actually anything) on 32bit. Secondly, this way around the error is *so* subtle because of the compatibility mode, the other way around if anyone would run `arma3server_x64` on a 32bit system, they would be immediately be hit with an error message saying something about x64 being in the wrong architecture and it would be obvious to use the other executable.